### PR TITLE
Fix unresolved references and some incremental steps to python 3

### DIFF
--- a/src/apply_wb_mask.py
+++ b/src/apply_wb_mask.py
@@ -44,16 +44,16 @@ def create_wb_mask_file(xmin,ymin,xmax,ymax,res,gcs=True):
 
     else:
         if ymin > 0:
-	     mask_file = "{}/WB_MASKS/Antimeridian_UTM1N_WaterMask1.tif".format(cfgdir)
-	else:
-	     mask_file = "{}/WB_MASKS/Antimeridian_UTM1S_WaterMask1.tif".format(cfgdir)
-	tmpfile = "water_mask.tif"
-	
-	coords = [xmin,ymax,xmax,ymin]
-	gdal.Translate(tmpfile,mask_file,projWin=coords,xRes=res,yRes=res)
-	x,y,trans,proj,data = saa.read_gdal_file(saa.open_gdal_file(tmpfile))
-	final_mask = data
-#	os.remove(tmpfile)
+            mask_file = "{}/WB_MASKS/Antimeridian_UTM1N_WaterMask1.tif".format(cfgdir)
+        else:
+            mask_file = "{}/WB_MASKS/Antimeridian_UTM1S_WaterMask1.tif".format(cfgdir)
+        tmpfile = "water_mask.tif"
+
+        coords = [xmin,ymax,xmax,ymin]
+        gdal.Translate(tmpfile,mask_file,projWin=coords,xRes=res,yRes=res)
+        x,y,trans,proj,data = saa.read_gdal_file(saa.open_gdal_file(tmpfile))
+        final_mask = data
+        # os.remove(tmpfile)
 
     return(final_mask)
 

--- a/src/asf_geometry.py
+++ b/src/asf_geometry.py
@@ -9,6 +9,7 @@ from scipy import ndimage
 import numpy as np
 from osgeo.gdalconst import GA_ReadOnly
 from saa_func_lib import get_zone
+import logging
 
 # Determine the boundary polygon of a GeoTIFF file
 def geotiff2polygon_ext(geotiff):
@@ -396,12 +397,12 @@ def spatial_query(source, reference, function):
   # Extract information from tiles and boundary shapefiles
   (geoTile, spatialRef, nameTile) = shape2geometry(reference, 'tile')
   if geoTile is None:
-    log.error('Could not extract information (tile) out of shapefile (%s)' %
+    logging.error('Could not extract information (tile) out of shapefile (%s)' %
       reference)
     sys.exit(1)
   (boundary, spatialRef, granule) = shape2geometry(source, 'granule')
   if boundary is None:
-    log.error('Could not extract information (granule) out of shapefile (%s)' %
+    logging.error('Could not extract information (granule) out of shapefile (%s)' %
       source)
     sys.exit(1)
 

--- a/src/asf_time_series.py
+++ b/src/asf_time_series.py
@@ -10,6 +10,7 @@ import netCDF4 as nc
 from statsmodels.tsa.seasonal import seasonal_decompose
 import statsmodels.api as sm
 from scipy.interpolate import interp1d
+from asf_geometry import geometry_proj2geo, raster_meta
 
 tolerance = 0.00005
 

--- a/src/byteSigmaScale.py
+++ b/src/byteSigmaScale.py
@@ -19,7 +19,7 @@ def get2sigmacutoffs(fi):
 
 def byteSigmaScale(infile,outfile):
     lo,hi = get2sigmacutoffs(infile)
-    print "2-sigma cutoffs are {} {}".format(lo,hi)
+    print("2-sigma cutoffs are {} {}".format(lo, hi))
     gdal.Translate(outfile,infile,outputType=gdal.GDT_Byte,scaleParams=[[lo,hi,1,255]],resampleAlg="average",noData="0")
 
     # For some reason, I'm still getting zeros in my byte images eventhough I'm using 1,255 scaling!

--- a/src/copy_metadata.py
+++ b/src/copy_metadata.py
@@ -11,7 +11,7 @@ def copy_metadata(infile, outfile):
     md = ds.GetMetadata()
     print(md)
 
-#    ds = saa.open_gdal_file(outfile)
+    #    ds = saa.open_gdal_file(outfile)
 #    ds.SetMetadata(md)
 
     outfile2 = "tmp_outfile.tif"

--- a/src/copy_metadata.py
+++ b/src/copy_metadata.py
@@ -9,7 +9,7 @@ from osgeo import gdal
 def copy_metadata(infile, outfile):
     ds = saa.open_gdal_file(infile)
     md = ds.GetMetadata()
-    print md
+    print(md)
 
 #    ds = saa.open_gdal_file(outfile)
 #    ds.SetMetadata(md)

--- a/src/cutGeotiffs.py
+++ b/src/cutGeotiffs.py
@@ -76,7 +76,13 @@ def cutFiles(arg):
     # Open file1, get projection and pixsize
     dst1 = gdal.Open(file1)
     p1 = dst1.GetProjection()
-    
+
+    # Find the largest pixel size of all scenes
+    pixSize = getPixSize(arg[0])
+    for x in range(len(arg) - 1):
+        tmp = getPixSize(arg[x + 1])
+        pixSize = max(pixSize, tmp)
+
     # Make sure that UTM projections match
     ptr = p1.find("UTM zone ")
     if ptr != -1:
@@ -102,19 +108,13 @@ def cutFiles(arg):
                 print("    reprojecting post image")
                 print("    proj is %s" % proj)
                 name = file2.replace(".tif","_reproj.tif")
-                gdal.Warp(name,file2,dstSRS=proj,xRes=pixsize,yRes=pixsize)
+                gdal.Warp(name,file2,dstSRS=proj,xRes=pixSize,yRes=pixSize)
                 arg[x+1] = name
 
     # Find the overlap between all scenes
     coords = getCorners(arg[0])
     for x in range (len(arg)-1):
         coords = getOverlap(coords,arg[x+1])
-    
-    # Find the largest pixel size of all scenes
-    pixSize = getPixSize(arg[0])
-    for x in range (len(arg)-1):
-        tmp = getPixSize(arg[x+1])
-        pixSize = max(pixSize,tmp)
     
     # Check to make sure there was some overlap
     print("Clipping coordinates: {}".format(coords))

--- a/src/cutGeotiffs.py
+++ b/src/cutGeotiffs.py
@@ -68,7 +68,7 @@ def getOverlap(coords,fi):
 def cutFiles(arg):
 
     if len(arg) == 1:
-        print "Nothing to do!!!  Exiting..."
+        print("Nothing to do!!!  Exiting...")
         return(0)
 
     file1 = arg[0]
@@ -94,13 +94,13 @@ def cutFiles(arg):
             zone2 = int(zone2[0])
 
             if zone1 != zone2:
-                print "Projections don't match... Reprojecting %s" % file2
+                print("Projections don't match... Reprojecting %s" % file2)
                 if hemi == "N":
                     proj = ('EPSG:326%02d' % int(zone1))
                 else:
                     proj = ('EPSG:327%02d' % int(zone1))
-	        print "    reprojecting post image"
-                print "    proj is %s" % proj
+                print("    reprojecting post image")
+                print("    proj is %s" % proj)
                 name = file2.replace(".tif","_reproj.tif")
                 gdal.Warp(name,file2,dstSRS=proj,xRes=pixsize,yRes=pixsize)
                 arg[x+1] = name
@@ -120,10 +120,10 @@ def cutFiles(arg):
     print("Clipping coordinates: {}".format(coords))
     diff1 = (coords[2] - coords[0]) / pixSize
     diff2 = (coords[3] - coords[1]) / pixSize * -1.0
-    print "Found overlap size of {}x{}".format(int(diff1),int(diff2))
+    print("Found overlap size of {}x{}".format(int(diff1), int(diff2)))
     if diff1 < 1 or diff2 < 1:
-         print "ERROR:  There was no overlap between scenes"
-         exit(1) 
+         print("ERROR:  There was no overlap between scenes")
+         exit(1)
     # Finally, clip all scenes to the overlap region at the largest pixel size
     lst = list(coords)
     tmp = lst[3]
@@ -134,8 +134,8 @@ def cutFiles(arg):
     for x in range (len(arg)):
         file1 = arg[x]
         file1_new = file1.replace('.tif','_clip.tif')
-        print "    clipping file {} to create file {}".format(file1,file1_new)
-#        dst_d1 = gdal.Translate(file1_new,file1,projWin=coords,xRes=pixSize,yRes=pixSize,creationOptions = ['COMPRESS=LZW'])
+        print("    clipping file {} to create file {}".format(file1, file1_new))
+        #        dst_d1 = gdal.Translate(file1_new,file1,projWin=coords,xRes=pixSize,yRes=pixSize,creationOptions = ['COMPRESS=LZW'])
         gdal.Warp(file1_new,file1,outputBounds=coords,xRes=pixSize,yRes=-1*pixSize,creationOptions = ['COMPRESS=LZW'])
 
 if __name__ == "__main__":

--- a/src/cutGeotiffs.py
+++ b/src/cutGeotiffs.py
@@ -114,7 +114,7 @@ def cutFiles(arg):
     pixSize = getPixSize(arg[0])
     for x in range (len(arg)-1):
         tmp = getPixSize(arg[x+1])
-	pixSize = max(pixSize,tmp)
+        pixSize = max(pixSize,tmp)
     
     # Check to make sure there was some overlap
     print("Clipping coordinates: {}".format(coords))

--- a/src/cutGeotiffsByLine.py
+++ b/src/cutGeotiffsByLine.py
@@ -50,10 +50,10 @@ def cutGeotiffsByLine(files,all_coords=None,all_pixsize=None):
    
     diff_ul[0] = (max(ul[0])-ul[0])/xres    
     diff_ul[1] = -1*(min(ul[1])-ul[1])/(-1*yres)
- 
-    print "Difference list:"
-    print diff_ul
- 
+
+    print("Difference list:")
+    print(diff_ul)
+
     lrx = min(lr[0])
     lry = max(lr[1])
     lenx = (lrx-max(ul[0])) / xres
@@ -61,14 +61,14 @@ def cutGeotiffsByLine(files,all_coords=None,all_pixsize=None):
     if leny < 0:
         leny = abs(leny)
         diff_ul[1] = diff_ul[1] * -1
-    print "Size of output images {} x {}".format(lenx,leny)
+    print("Size of output images {} x {}".format(lenx, leny))
 
     outfiles = []   
     for i in range(len(files)):
         outfile = files[i].replace(".tif","_cut.tif")
 	if all_coords is not None:
 	    outfile = os.path.basename(outfile)
-	print "Processing file {} to create file {}".format(files[i],outfile)
+        print("Processing file {} to create file {}".format(files[i], outfile))
         gdal.Translate(outfile,files[i],srcWin=[diff_ul[0,i],diff_ul[1,i],lenx,leny],noData=0)
         outfiles.append(outfile)
 

--- a/src/cutGeotiffsByLine.py
+++ b/src/cutGeotiffsByLine.py
@@ -66,8 +66,8 @@ def cutGeotiffsByLine(files,all_coords=None,all_pixsize=None):
     outfiles = []   
     for i in range(len(files)):
         outfile = files[i].replace(".tif","_cut.tif")
-	if all_coords is not None:
-	    outfile = os.path.basename(outfile)
+        if all_coords is not None:
+            outfile = os.path.basename(outfile)
         print("Processing file {} to create file {}".format(files[i], outfile))
         gdal.Translate(outfile,files[i],srcWin=[diff_ul[0,i],diff_ul[1,i],lenx,leny],noData=0)
         outfiles.append(outfile)

--- a/src/execute.py
+++ b/src/execute.py
@@ -28,6 +28,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 ###############################################################################
+import os
 import subprocess
 import logging
 

--- a/src/file_subroutines.py
+++ b/src/file_subroutines.py
@@ -37,10 +37,10 @@ def get_file_list():
             m = [myfile,t[4][0:15]]
             files.append(m)
             i = i+1
-	
-    print 'Found %s files to process' % i
+
+    print('Found %s files to process' % i)
     files.sort(key = lambda row: row[1])
-    print files
+    print(files)
 
     for i in range(len(files)): 
         filenames.append(files[i][0])

--- a/src/getDemFor.py
+++ b/src/getDemFor.py
@@ -35,6 +35,7 @@
 from lxml import etree
 import get_dem
 import os
+import sys
 import argparse
 from getSubSwath import get_bounding_box_file
 from execute import execute

--- a/src/getDemFor.py
+++ b/src/getDemFor.py
@@ -51,12 +51,12 @@ def getDemFile(infile,outfile,opentopoFlag=None,utmFlag=None,post=None,demName=N
         if utmFlag:
             proj = get_utm_proj(lon_min,lon_max,lat_min,lat_max)
             gdal.Warp("tmpdem.tif","%s" % outfile,dstSRS=proj,resampleAlg="cubic")
-	    shutil.move("tmpdem.tif","%s" % outfile)
+            shutil.move("tmpdem.tif","%s" % outfile)
     else:
         if post is not None:
              if not utmFlag:
-	        logging.error("ERROR: May use posting with UTM projection only")
-	        sys.exit(1)
+                logging.error("ERROR: May use posting with UTM projection only")
+                sys.exit(1)
         demtype = get_dem.get_dem(lon_min,lat_min,lon_max,lat_max,outfile,utmFlag,post,demName=demName)
 
     return(outfile,demtype)

--- a/src/getParameter.py
+++ b/src/getParameter.py
@@ -28,7 +28,7 @@ def getParameter(parFile,parameter,uselogging=False):
         if uselogging:
             logging.error("ERROR: Unable to find parameter {} in file {}".format(parameter,parFile))
         else:
-            print "ERROR: Unable to find parameter {} in file {}".format(parameter,parFile)
+            print("ERROR: Unable to find parameter {} in file {}".format(parameter, parFile))
         exit(1)
     return value
 

--- a/src/getSubSwath.py
+++ b/src/getSubSwath.py
@@ -216,8 +216,8 @@ def get_real_cc(myxml):
 	    lons.append(i[5].text)
 		        
     if len(lats) != 4 or len(lons) != 4:
-        print "ERROR: Unable to find corner points!"
-	exit(1)
+        print("ERROR: Unable to find corner points!")
+        exit(1)
     return lats, lons
 
 ###############################################################################

--- a/src/getSubSwath.py
+++ b/src/getSubSwath.py
@@ -139,19 +139,19 @@ def SelectSubswath(safeFile,lon_min,lat_min,lon_max,lat_max):
     ss = 0
     if (area1 > area2):
         if (area1 > area3):
-	    ss = 1
-	    i = intersect1
-	else:
-	    ss = 3
-	    i = intersect3
+            ss = 1
+            i = intersect1
+        else:
+            ss = 3
+            i = intersect3
     else:
         if (area2 > area3):
-	    ss = 2
-	    i = intersect2
-	else:
-	    if (area3 > 0):
-	        ss = 3
-  	        i = intersect3
+            ss = 2
+            i = intersect2
+        else:
+            if (area3 > 0):
+                ss = 3
+                i = intersect3
 
     return ss, i.GetEnvelope()
 
@@ -184,37 +184,37 @@ def get_real_cc(myxml):
 
     for i in root.iter('numberOfLines'):
         nl = int(i.text)
-	
+        
     for i in root.iter('geolocationGridPoint'):
         line = int(i[2].text)
-	samp = int(i[3].text)
-	if samp==0 and line==0:
-	    lats.append(i[4].text)
-	    lons.append(i[5].text)
+        samp = int(i[3].text)
+        if samp==0 and line==0:
+            lats.append(i[4].text)
+            lons.append(i[5].text)
 
     for i in root.iter('geolocationGridPoint'):
         line = int(i[2].text)
-	samp = int(i[3].text)
-	# the last line is sometimes nl, sometimes nl-1
-	if samp==0 and (abs(line-nl) <= 1):
-	    lats.append(i[4].text)
-	    lons.append(i[5].text)
-	    
+        samp = int(i[3].text)
+        # the last line is sometimes nl, sometimes nl-1
+        if samp==0 and (abs(line-nl) <= 1):
+            lats.append(i[4].text)
+            lons.append(i[5].text)
+            
     for i in root.iter('geolocationGridPoint'):
         line = int(i[2].text)
-	samp = int(i[3].text)
-	# the last line is sometimes nl, sometimes nl-1
-	if samp==ns-1 and (abs(line-nl) <= 1):
-	    lats.append(i[4].text)
-	    lons.append(i[5].text)
+        samp = int(i[3].text)
+        # the last line is sometimes nl, sometimes nl-1
+        if samp==ns-1 and (abs(line-nl) <= 1):
+            lats.append(i[4].text)
+            lons.append(i[5].text)
 
     for i in root.iter('geolocationGridPoint'):
         line = int(i[2].text)
-	samp = int(i[3].text)
+        samp = int(i[3].text)
         if samp==ns-1 and line==0:
-	    lats.append(i[4].text)
-	    lons.append(i[5].text)
-		        
+            lats.append(i[4].text)
+            lons.append(i[5].text)
+                        
     if len(lats) != 4 or len(lons) != 4:
         print("ERROR: Unable to find corner points!")
         exit(1)
@@ -266,14 +266,14 @@ def SelectAllSubswaths(safeFile,lon_min,lat_min,lon_max,lat_max):
     
     if area1 > 0.0:
         ss.append(1)
-	polygon.append(intersect1.GetEnvelope())
+        polygon.append(intersect1.GetEnvelope())
    
     if area2 > 0.0:
         ss.append(2)
-	polygon.append(intersect2.GetEnvelope())
-	
+        polygon.append(intersect2.GetEnvelope())
+        
     if area3 > 0.0:
         ss.append(3)
-	polygon.append(intersect3.GetEnvelope())
-	
+        polygon.append(intersect3.GetEnvelope())
+        
     return ss, polygon

--- a/src/get_bb_from_shape.py
+++ b/src/get_bb_from_shape.py
@@ -45,6 +45,6 @@ def get_bb_from_shape(shapeFile):
   maxX = envelope[1]
   maxY = envelope[3]
 
-  print minX,minY,maxX,maxY
+  print(minX, minY, maxX, maxY)
 
   return(minX,minY,maxX,maxY)

--- a/src/get_dem.py
+++ b/src/get_dem.py
@@ -195,7 +195,7 @@ def anti_meridian_kludge(dem_file,dem_name,south,lat_min,lat_max,lon_min,lon_max
                     s3 = boto3.resource('s3')
                     s3.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
                     mybucket = mydir.split("/")[-1]
-                    s3.Bucket(mybucket).download_file(myfile,"DEM/{}.tif".format(fi))
+                    s3.Bucket(mybucket).download_file(myfile,"DEM/{}".format(dem_file))
                 else:
                     myfile = os.path.join(mydir,dem_file)
                     logging.info("Tile: {}".format(myfile))

--- a/src/get_dem.py
+++ b/src/get_dem.py
@@ -259,7 +259,7 @@ def get_dem(lon_min,lat_min,lon_max,lat_max,outfile,utmflag,post=None, processes
         sys.exit(1)
 
     if lat_min < -90 or lat_max > 90:
-        loggging.error("ERROR: Please use latitude in range (-90,90) %s %s" % (lat_min,lat_max))
+        logging.error("ERROR: Please use latitude in range (-90,90) %s %s" % (lat_min,lat_max))
         sys.exit(1)
 
     if lon_min > lon_max:

--- a/src/get_dem.py
+++ b/src/get_dem.py
@@ -237,11 +237,12 @@ def anti_meridian_kludge(dem_file,dem_name,south,lat_min,lat_max,lon_min,lon_max
 
 # GET DEM file and convert into ISCE format
 def get_ISCE_dem(west,south,east,north,demName,demXMLName):
-        get_dem(west,south,east,north,"temp_dem.tif",False)
-        gdal.Translate(demName,"temp_dem.tif",format="ENVI")
-        ext = os.path.splitext(demName)[1]
-        hdrName = demName.replace(ext,".hdr")
-        dem2isce.dem2isce(demName,hdrName,demXMLName)
+    chosen_dem = get_dem(west,south,east,north,"temp_dem.tif",False)
+    gdal.Translate(demName,"temp_dem.tif",format="ENVI")
+    ext = os.path.splitext(demName)[1]
+    hdrName = demName.replace(ext,".hdr")
+    dem2isce.dem2isce(demName,hdrName,demXMLName)
+    return chosen_dem
 
 def get_dem(lon_min,lat_min,lon_max,lat_max,outfile,utmflag,post=None, processes=1,demName=None):
 

--- a/src/get_dem.py
+++ b/src/get_dem.py
@@ -193,7 +193,7 @@ def anti_meridian_kludge(dem_file,dem_name,south,lat_min,lat_max,lon_min,lon_max
                 if "s3" in mydir:
                     myfile = os.path.join(dem_name,dem_file)
                     s3 = boto3.resource('s3')
-                    resource.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
+                    s3.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
                     mybucket = mydir.split("/")[-1]
                     s3.Bucket(mybucket).download_file(myfile,"DEM/{}.tif".format(fi))
                 else:

--- a/src/get_orb.py
+++ b/src/get_orb.py
@@ -139,8 +139,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     for g in sys.argv[1:]:
-        print "Getting: " + g
+        print("Getting: " + g)
         (orburl,f1) = getOrbFile(g)
-        print orburl
+        print(orburl)
         cmd = 'wget ' + orburl
         os.system(cmd)

--- a/src/get_orb.py
+++ b/src/get_orb.py
@@ -9,7 +9,7 @@ import sys
 import argparse
 import requests
 from requests.adapters import HTTPAdapter
-from urlparse import urlparse
+from six.moves.urllib import parse as urlparse
 
 
 class FileException(Exception):

--- a/src/ingest_S1_granule.py
+++ b/src/ingest_S1_granule.py
@@ -34,20 +34,20 @@ def ingest_S1_granule(inFile,pol,look_fact,outFile):
                 execute(cmd,uselogging=True)
         except:
             logging.warning("Unable to fetch precision state vectors... continuing")
-	
+        
         # Multi-look the image
         if look_fact > 1.0:
             cmd = "multi_look_MLI {grd} {grd}.par {outFile} {outFile}.par {lks} {lks}".format(grd=grd,outFile=outFile,lks=look_fact)
             execute(cmd,uselogging=True)
         else:
-	    shutil.copy(grd,outFile)
+            shutil.copy(grd,outFile)
             shutil.copy("{}.par".format(grd),"{}.par".format(outFile))
 
     else:
         #  Ingest SLC data files into gamma format
         par_s1_slc_single(inFile,pol)
         date = inFile[17:25]
-	make_tab_flag = True
+        make_tab_flag = True
         burst_tab = getBursts(inFile,make_tab_flag)
         shutil.copy(burst_tab,date)
 

--- a/src/iscegeo2geotif.py
+++ b/src/iscegeo2geotif.py
@@ -107,21 +107,21 @@ def convert_files(s1aFlag,proj=None,res=30):
         gdal.Translate("phase.tif","filt_topophase.unw.geo",bandList=[2],creationOptions = ['COMPRESS=PACKBITS'])
         shutil.copy("phase.tif",gcsname)        
     else:
-        print "Creating tmp.tif"
+        print("Creating tmp.tif")
         gdal.Translate("tmp.tif","filt_topophase.unw.geo.vrt",bandList=[2],creationOptions = ['COMPRESS=PACKBITS'])
-        print "phase.tif"
+        print("phase.tif")
         gdal.Warp("phase.tif","tmp.tif",dstSRS=proj,xRes=res,yRes=res,resampleAlg="cubic",dstNodata=0,creationOptions=['COMPRESS=LZW'])
-        print "mv tmp.tif {}".format(gcsname)
-        shutil.copy("tmp.tif",gcsname)        
+        print("mv tmp.tif {}".format(gcsname))
+        shutil.copy("tmp.tif",gcsname)
 #        os.remove("tmp.tif")
 
-        print "Creating browse image colorized_unw.png"
+        print("Creating browse image colorized_unw.png")
         create_browse("unw.png","colorized_unw.png","colorized_unw.png.aux.xml",gcsname,proj,1024)
         create_browse("unw.png","colorized_unw_large.png","colorized_unw_large.png.aux.xml",gcsname,proj,2048)
-        
-        print "Creating browse image color.png"
+
+        print("Creating browse image color.png")
         create_browse("col.png","color.png","color.png.aux.xml",gcsname,proj,1024)
-        print "Creating browse image color_large.png"
+        print("Creating browse image color_large.png")
         create_browse("col.png","color_large.png","color_large.png.aux.xml",gcsname,proj,2048)
 
 

--- a/src/makeAsfBrowse.py
+++ b/src/makeAsfBrowse.py
@@ -13,7 +13,7 @@ def makeAsfBrowse(geotiff, baseName, use_nn=False):
     lrgName = baseName + "_large.png"
     x1,y1,trans1,proj1 = saa.read_gdal_file_geo(saa.open_gdal_file(geotiff))
     if (x1 < 2048):
-        print "Warning: width exceeds image dimension - using actual value"
+        print("Warning: width exceeds image dimension - using actual value")
         resample_geotiff(geotiff,x1,"KML",kmzName,use_nn)
         if x1 < 1024:      
             resample_geotiff(geotiff,x1,"PNG",pngName,use_nn)

--- a/src/makeChangeBrowse.py
+++ b/src/makeChangeBrowse.py
@@ -81,7 +81,7 @@ def makeChangeBrowse(geotiff,type="MSCD"):
         #
         lut = np.zeros(class_cnt,dtype=np.uint8)
         if class_cnt == 1:
-            print "ERROR: Only found one class"
+            print("ERROR: Only found one class")
             exit(1)
         if (class_cnt == 2):
             lut[0] = 0

--- a/src/makeColorPhase.py
+++ b/src/makeColorPhase.py
@@ -162,7 +162,7 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
         greenf = np.zeros(data.shape)
         bluef = np.zeros(data.shape)
 
- 	# Scale from 0 .. 1
+         # Scale from 0 .. 1
         redf[::] = red[::]/255.0
         greenf[::] = green[::]/255.0
         bluef[::] = blue[::]/255.0
@@ -170,7 +170,7 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
         # Read in the amplitude data
         x1,y1,trans1,proj1 = saa.read_gdal_file_geo(saa.open_gdal_file(ampFile))
 
-	# If too large, resize the data
+        # If too large, resize the data
         if x1 > 4096 or y1 > 4096:
             ampTmp = "{}_small.tif".format(os.path.basename(ampFile.replace(".tif","")))
             gdal.Translate(ampTmp,ampFile,height=y,width=x)
@@ -234,7 +234,7 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
         # Scale amplitude from 0.0 to 1.0
         ampf = np.zeros(data.shape)
         ampf = amp / 255.0
-	ampf = ampf + float(scale)
+        ampf = ampf + float(scale)
         ampf[ampf>1.0]=1.0
 
         print("SCALED AMP HISTOGRAM:")

--- a/src/makeColorPhase.py
+++ b/src/makeColorPhase.py
@@ -52,7 +52,7 @@ def createAmp(fi):
     (x,y,trans,proj,data) = saa.read_gdal_file(saa.open_gdal_file(fi))
     ampdata = np.sqrt(data)
     outfile = fi.replace('.tif','-amp.tif')
-    print outfile
+    print(outfile)
     saa.write_gdal_file_float(outfile,trans,proj,ampdata)
     return outfile
 
@@ -73,7 +73,7 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
     elif table=='RWB':
         R, G, B = makeRWBColor(samples)
     else:
-        print "ERROR: Unknown color table: {}".format(table)
+        print("ERROR: Unknown color table: {}".format(table))
         exit(1)
 
     #
@@ -86,10 +86,10 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
         phaseTmp = "{}_small.tif".format(os.path.basename(inFile.replace(".tif","")))
         gdal.Translate(phaseTmp,inFile,height=4096)
         x,y,trans,proj,data = saa.read_gdal_file(saa.open_gdal_file(phaseTmp))
-        print "Created small tif of size {} x {}".format(x,y)
+        print("Created small tif of size {} x {}".format(x, y))
     else:
         x,y,trans,proj,data= saa.read_gdal_file(saa.open_gdal_file(inFile))
-        print "Using full size tif of size {} x {}".format(x,y)
+        print("Using full size tif of size {} x {}".format(x, y))
         phaseTmp = inFile
         
     # Make a black mask for use after colorization
@@ -122,13 +122,13 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
    
         data[:] = (data[:] - mini) / (maxi - mini)
         data[:] = data * float(samples)
-        
-        print np.max(data)
-        print np.min(data)
-        
+
+        print(np.max(data))
+        print(np.min(data))
+
         hist = np.histogram(data)
-        print hist[1]
-        print hist[0]
+        print(hist[1])
+        print(hist[0])
 
     data[data==samples]=samples-1
 
@@ -191,9 +191,8 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
             ampTmp = ampTmp.replace(".tif","_clip.tif")
             x1,y1,trans1,proj1,amp = saa.read_gdal_file(saa.open_gdal_file(ampTmp))
 
-        print "Data shape is {}".format(data.shape)
-        print "Amp shape is {}".format(amp.shape)
-       
+        print("Data shape is {}".format(data.shape))
+        print("Amp shape is {}".format(amp.shape))
 
         # Make a black mask for use after colorization
         mask = np.ones(amp.shape,dtype=np.uint8)
@@ -203,18 +202,18 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
         amp[mask==0]=0
 
         ave = np.mean(amp)
-        print "Mean of amp data is {}".format(ave)
+        print("Mean of amp data is {}".format(ave))
         amp[mask==0]=ave
 
-        print "AMP HISTOGRAM:"
+        print("AMP HISTOGRAM:")
         hist = np.histogram(amp)
-        print hist[1]
-        print hist[0]
+        print(hist[1])
+        print(hist[0])
 
         ave = np.mean(amp)
-        print "Amp average is {}".format(ave)
-        print "Amp median is {}".format(np.median(amp))
-        print "Amp stddev is {}".format(np.std(amp))
+        print("Amp average is {}".format(ave))
+        print("Amp median is {}".format(np.median(amp)))
+        print("Amp stddev is {}".format(np.std(amp)))
 
         # Rescale amplitude to 2-sigma byte range, otherwise may be all dark
         amp2File = createAmp(ampTmp)
@@ -226,22 +225,22 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
 #            os.remove(ampTmp)
 #        os.remove(amp2File)
 #        os.remove(newFile)
-        
-        print "2-sigma AMP HISTOGRAM:"
+
+        print("2-sigma AMP HISTOGRAM:")
         hist = np.histogram(amp)
-        print hist[1]
-        print hist[0]
+        print(hist[1])
+        print(hist[0])
 
         # Scale amplitude from 0.0 to 1.0
         ampf = np.zeros(data.shape)
         ampf = amp / 255.0
 	ampf = ampf + float(scale)
         ampf[ampf>1.0]=1.0
-        
-        print "SCALED AMP HISTOGRAM:"
+
+        print("SCALED AMP HISTOGRAM:")
         hist = np.histogram(ampf)
-        print hist[1]
-        print hist[0]
+        print(hist[1])
+        print(hist[0])
 
         # Perform color transformation 
         h = np.zeros(data.shape)
@@ -251,18 +250,18 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
         for j in range(x):
             for i in range(y):
                 h[i,j],l[i,j],s[i,j] = colorsys.rgb_to_hls(redf[i,j],greenf[i,j],bluef[i,j])
-                
-        print "LIGHTNESS HISTOGRAM:"
+
+        print("LIGHTNESS HISTOGRAM:")
         hist = np.histogram(l)
-        print hist[1]
-        print hist[0]
-                
+        print(hist[1])
+        print(hist[0])
+
         l = l * ampf
-        
-        print "NEW LIGHTNESS HISTOGRAM:"
+
+        print("NEW LIGHTNESS HISTOGRAM:")
         hist = np.histogram(l)
-        print hist[1]
-        print hist[0]
+        print(hist[1])
+        print(hist[0])
 
         for j in range(x):
             for i in range(y):
@@ -271,11 +270,11 @@ def makeColorPhase(inFile,rateReduction=1,shift=0,ampFile=None,scale=0,table='CM
         red = redf * 255
         green = greenf * 255
         blue = bluef * 255
-       
-        print "TRANFORMED RED HISTOGRAM:"
+
+        print("TRANFORMED RED HISTOGRAM:")
         hist = np.histogram(red)
-        print hist[1]
-        print hist[0]
+        print(hist[1])
+        print(hist[0])
 
         # Apply mask
         red[mask==0]=0

--- a/src/make_arc_thumb.py
+++ b/src/make_arc_thumb.py
@@ -19,10 +19,10 @@ def pngtothumb(pngfile):
     
     if x>y:
         width = 200
-	length = 200 * y/x
+        length = 200 * y/x
     else:
         length = 200
-	width = 200 * x/y
+        width = 200 * x/y
 
     size = length,width
     thumb = rgb_im.thumbnail(size)

--- a/src/make_cogs.py
+++ b/src/make_cogs.py
@@ -19,7 +19,7 @@ def cogify_dir(dir="PRODUCT",debug=False,res=30):
     os.chdir(back)
 
 def make_cog(inFile,outFile,debug=False,res=30):
-    print "Creating COG file {} from input file {}".format(outFile,inFile)
+    print("Creating COG file {} from input file {}".format(outFile, inFile))
     tmpFile = 'cog_{}.tif'.format(os.getpid())
     shutil.copy(inFile,tmpFile)
 

--- a/src/par_s1_slc_single.py
+++ b/src/par_s1_slc_single.py
@@ -88,7 +88,7 @@ def par_s1_slc_single(myfile,pol=None):
 
     # Fetch precision state vectors
     try:
-        url,orb = getOrbFile(inFile)
+        url,orb = getOrbFile(myfile)
         cmd = "wget {}".format(url)
         logging.info("Getting precision orbit information")
         execute(cmd,uselogging=True)

--- a/src/raster_boundary2shape.py
+++ b/src/raster_boundary2shape.py
@@ -1,74 +1,10 @@
 #!/usr/bin/python
 import argparse
 from argparse import RawTextHelpFormatter
-import os
-from osgeo import gdal, ogr, osr
-import sys
+
 from asf_geometry import *
-
-# from asf_time_series import raster_metadata
+from asf_time_series import raster_metadata
  
-def raster_metadata(input):
-
-  # Set up shapefile attributes
-  fields = []
-  field = {}
-  values = []
-  field['name'] = 'granule'
-  field['type'] = ogr.OFTString
-  field['width'] = 254
-  fields.append(field)
-  field = {}
-  field['name'] = 'epsg'
-  field['type'] = ogr.OFTInteger
-  fields.append(field)
-  field = {}
-  field['name'] = 'originX'
-  field['type'] = ogr.OFTReal
-  fields.append(field)
-  field = {}
-  field['name'] = 'originY'
-  field['type'] = ogr.OFTReal
-  fields.append(field)
-  field = {}
-  field['name'] = 'pixSize'
-  field['type'] = ogr.OFTReal
-  fields.append(field)
-  field = {}
-  field['name'] = 'cols'
-  field['type'] = ogr.OFTInteger
-  fields.append(field)
-  field = {}
-  field['name'] = 'rows'
-  field['type'] = ogr.OFTInteger
-  fields.append(field)
-  field = {}
-  field['name'] = 'pixel'
-  field['type'] = ogr.OFTString
-  field['width'] = 8
-  fields.append(field)
-
-  # Extract other raster image metadata
-  (outSpatialRef, outGt, outShape, outPixel) = raster_meta(input)
-  if outSpatialRef.GetAttrValue('AUTHORITY', 0) == 'EPSG':
-    epsg = int(outSpatialRef.GetAttrValue('AUTHORITY', 1))
-
-  # Add granule name and geometry
-  base = os.path.basename(input)
-  granule = os.path.splitext(base)[0]
-  value = {}
-  value['granule'] = granule
-  value['epsg'] = epsg
-  value['originX'] = outGt[0]
-  value['originY'] = outGt[3]
-  value['pixSize'] = outGt[1]
-  value['cols'] = outShape[1]
-  value['rows'] = outShape[0]
-  value['pixel'] = outPixel
-  values.append(value)
-
-  return (fields, values, outSpatialRef)
-
 
 def raster_boundary2shape(inFile, threshold, outShapeFile):
     # Extract raster image metadata

--- a/src/raster_boundary2shape.py
+++ b/src/raster_boundary2shape.py
@@ -1,10 +1,74 @@
 #!/usr/bin/python
 import argparse
 from argparse import RawTextHelpFormatter
-
+import os
+from osgeo import gdal, ogr, osr
+import sys
 from asf_geometry import *
-from asf_time_series import raster_metadata
+
+# from asf_time_series import raster_metadata
  
+def raster_metadata(input):
+
+  # Set up shapefile attributes
+  fields = []
+  field = {}
+  values = []
+  field['name'] = 'granule'
+  field['type'] = ogr.OFTString
+  field['width'] = 254
+  fields.append(field)
+  field = {}
+  field['name'] = 'epsg'
+  field['type'] = ogr.OFTInteger
+  fields.append(field)
+  field = {}
+  field['name'] = 'originX'
+  field['type'] = ogr.OFTReal
+  fields.append(field)
+  field = {}
+  field['name'] = 'originY'
+  field['type'] = ogr.OFTReal
+  fields.append(field)
+  field = {}
+  field['name'] = 'pixSize'
+  field['type'] = ogr.OFTReal
+  fields.append(field)
+  field = {}
+  field['name'] = 'cols'
+  field['type'] = ogr.OFTInteger
+  fields.append(field)
+  field = {}
+  field['name'] = 'rows'
+  field['type'] = ogr.OFTInteger
+  fields.append(field)
+  field = {}
+  field['name'] = 'pixel'
+  field['type'] = ogr.OFTString
+  field['width'] = 8
+  fields.append(field)
+
+  # Extract other raster image metadata
+  (outSpatialRef, outGt, outShape, outPixel) = raster_meta(input)
+  if outSpatialRef.GetAttrValue('AUTHORITY', 0) == 'EPSG':
+    epsg = int(outSpatialRef.GetAttrValue('AUTHORITY', 1))
+
+  # Add granule name and geometry
+  base = os.path.basename(input)
+  granule = os.path.splitext(base)[0]
+  value = {}
+  value['granule'] = granule
+  value['epsg'] = epsg
+  value['originX'] = outGt[0]
+  value['originY'] = outGt[3]
+  value['pixSize'] = outGt[1]
+  value['cols'] = outShape[1]
+  value['rows'] = outShape[0]
+  value['pixel'] = outPixel
+  values.append(value)
+
+  return (fields, values, outSpatialRef)
+
 
 def raster_boundary2shape(inFile, threshold, outShapeFile):
     # Extract raster image metadata

--- a/src/rtc2colordiff.py
+++ b/src/rtc2colordiff.py
@@ -9,7 +9,6 @@ import datetime
 import shutil
 from osgeo import gdal, ogr, osr
 from asf_geometry import *
-from asf_utils import *
 from rtc2color import rtc2color
 from execute import execute
 
@@ -93,6 +92,21 @@ def check_projection(tmpDir, preFullpol, preCrosspol, postFullpol, postCrosspol)
       preCrosspol = crosspol
 
   return (preFullpol, preCrosspol, postFullpol, postCrosspol)
+
+
+def make_tmp_dir(path, prefix):
+    # Generate the temporary directory in location defined in the configuration
+    # file states. As general failover method generate a temporary directory in
+    # the current directory
+
+    tmpStr = prefix + '_' + datetime.datetime.utcnow().isoformat()
+    if path:
+        tmpDir = os.path.join(path, tmpStr)
+    else:
+        tmpDir = tmpStr
+    os.makedirs(tmpDir)
+
+    return tmpDir
 
 
 def rtc2colordiff(preFullpol, preCrosspol, postFullpol, postCrosspol, threshold,

--- a/src/saa_func_lib.py
+++ b/src/saa_func_lib.py
@@ -286,7 +286,7 @@ def boxcar_y(image,bsize):
         w = np.ones(bsize)
         edge = int((bsize-1)/2)
         for i in range (0,y):
-            progressbar(float(i)/float(y))
+            gdal.TermProgress_nocb(float(i)/float(y))
             outimage[i,:] = np.convolve(w/w.sum(),image[i,:],mode='same')
         print('100')
         return outimage
@@ -298,62 +298,13 @@ def boxcar_x(image,bsize):
         w = np.ones(bsize)
         edge = int((bsize-1)/2)
         for j in range (0,x):
-            progressbar(float(j)/float(x))
+            gdal.TermProgress_nocb(float(j)/float(x))
             outimage[:,j] = np.convolve(w/w.sum(),image[:,j],mode='same')
         print('100')
         return outimage
 
 def lee(image):
         return 1
-
-
-
-
-
-
-
-#####################
-#
-# Generic subroutines
-#
-#####################
-
-def resample():
-        return 1
-
-def parse_eq(equation):
-        return 1
-
-def progressbar(complete = 0.0):
-        gdal.TermProgress_nocb(complete)
-
-def Usage(message):
-    print("---------------------------------------")
-    print("Usage: ")
-    print(message )
-    print("---------------------------------------")
-
-def is_in_BB():
-        if bb:
-            return 1
-        else:
-            return 0
-
-def getText(nodelist):
-    rc = []
-    for node in nodelist:
-        if node.nodeType == node.TEXT_NODE:
-            rc.append(node.data)
-    return ''.join(rc)
-
-
-def getKMLcoords(file):
-    dom1 = xml.dom.minidom.parse(file)
-    north =  getText(dom1.getElementsByTagName("north")[0].childNodes)
-    south =  getText(dom1.getElementsByTagName("south")[0].childNodes)
-    east =  getText(dom1.getElementsByTagName("east")[0].childNodes)
-    west =  getText(dom1.getElementsByTagName("west")[0].childNodes)
-    return north,south,east,west
 
 
 #####################

--- a/src/six.py
+++ b/src/six.py
@@ -1,0 +1,953 @@
+# Copyright (c) 2010-2019 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Utilities for writing code that runs on Python 2 and 3"""
+
+from __future__ import absolute_import
+
+import functools
+import itertools
+import operator
+import sys
+import types
+
+__author__ = "Benjamin Peterson <benjamin@python.org>"
+__version__ = "1.12.0"
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+if PY3:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
+else:
+    string_types = basestring,
+    integer_types = (int, long)
+    class_types = (type, types.ClassType)
+    text_type = unicode
+    binary_type = str
+
+    if sys.platform.startswith("java"):
+        # Jython always uses 32 bits.
+        MAXSIZE = int((1 << 31) - 1)
+    else:
+        # It's possible to have sizeof(long) != sizeof(Py_ssize_t).
+        class X(object):
+
+            def __len__(self):
+                return 1 << 31
+        try:
+            len(X())
+        except OverflowError:
+            # 32-bit
+            MAXSIZE = int((1 << 31) - 1)
+        else:
+            # 64-bit
+            MAXSIZE = int((1 << 63) - 1)
+        del X
+
+
+def _add_doc(func, doc):
+    """Add documentation to a function."""
+    func.__doc__ = doc
+
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+
+
+class _LazyDescr(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+
+
+class MovedModule(_LazyDescr):
+
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+
+    def _resolve(self):
+        return _import_module(self.mod)
+
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+
+
+class _LazyModule(types.ModuleType):
+
+    def __init__(self, name):
+        super(_LazyModule, self).__init__(name)
+        self.__doc__ = self.__class__.__doc__
+
+    def __dir__(self):
+        attrs = ["__doc__", "__name__"]
+        attrs += [attr.name for attr in self._moved_attributes]
+        return attrs
+
+    # Subclasses should override this
+    _moved_attributes = []
+
+
+class MovedAttribute(_LazyDescr):
+
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+
+
+class _SixMetaPathImporter(object):
+
+    """
+    A meta path importer to import six.moves and its submodules.
+
+    This class implements a PEP302 finder and loader. It should be compatible
+    with Python 2.5 and all existing versions of Python3
+    """
+
+    def __init__(self, six_module_name):
+        self.name = six_module_name
+        self.known_modules = {}
+
+    def _add_module(self, mod, *fullnames):
+        for fullname in fullnames:
+            self.known_modules[self.name + "." + fullname] = mod
+
+    def _get_module(self, fullname):
+        return self.known_modules[self.name + "." + fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self.known_modules:
+            return self
+        return None
+
+    def __get_module(self, fullname):
+        try:
+            return self.known_modules[fullname]
+        except KeyError:
+            raise ImportError("This loader does not know module " + fullname)
+
+    def load_module(self, fullname):
+        try:
+            # in case of a reload
+            return sys.modules[fullname]
+        except KeyError:
+            pass
+        mod = self.__get_module(fullname)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        sys.modules[fullname] = mod
+        return mod
+
+    def is_package(self, fullname):
+        """
+        Return true, if the named module is a package.
+
+        We need this method to get correct spec objects with
+        Python 3.4 (see PEP451)
+        """
+        return hasattr(self.__get_module(fullname), "__path__")
+
+    def get_code(self, fullname):
+        """Return None
+
+        Required, if is_package is implemented"""
+        self.__get_module(fullname)  # eventually raises ImportError
+        return None
+    get_source = get_code  # same as get_code
+
+_importer = _SixMetaPathImporter(__name__)
+
+
+class _MovedItems(_LazyModule):
+
+    """Lazy loading of moved objects"""
+    __path__ = []  # mark as package
+
+
+_moved_attributes = [
+    MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
+    MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
+    MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("getoutput", "commands", "subprocess"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
+    MovedAttribute("StringIO", "StringIO", "io"),
+    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserList", "UserList", "collections"),
+    MovedAttribute("UserString", "UserString", "collections"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
+    MovedModule("builtins", "__builtin__"),
+    MovedModule("configparser", "ConfigParser"),
+    MovedModule("copyreg", "copy_reg"),
+    MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
+    MovedModule("http_cookies", "Cookie", "http.cookies"),
+    MovedModule("html_entities", "htmlentitydefs", "html.entities"),
+    MovedModule("html_parser", "HTMLParser", "html.parser"),
+    MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
+    MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
+    MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
+    MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
+    MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
+    MovedModule("cPickle", "cPickle", "pickle"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+    MovedModule("socketserver", "SocketServer"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("tkinter", "Tkinter"),
+    MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
+    MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
+    MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
+    MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
+    MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
+    MovedModule("tkinter_dnd", "Tkdnd", "tkinter.dnd"),
+    MovedModule("tkinter_colorchooser", "tkColorChooser",
+                "tkinter.colorchooser"),
+    MovedModule("tkinter_commondialog", "tkCommonDialog",
+                "tkinter.commondialog"),
+    MovedModule("tkinter_tkfiledialog", "tkFileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_font", "tkFont", "tkinter.font"),
+    MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
+    MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
+                "tkinter.simpledialog"),
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
+    MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
+    MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
+    MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
+]
+# Add windows specific modules.
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+
+for attr in _moved_attributes:
+    setattr(_MovedItems, attr.name, attr)
+    if isinstance(attr, MovedModule):
+        _importer._add_module(attr, "moves." + attr.name)
+del attr
+
+_MovedItems._moved_attributes = _moved_attributes
+
+moves = _MovedItems(__name__ + ".moves")
+_importer._add_module(moves, "moves")
+
+
+class Module_six_moves_urllib_parse(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_parse"""
+
+
+_urllib_parse_moved_attributes = [
+    MovedAttribute("ParseResult", "urlparse", "urllib.parse"),
+    MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
+    MovedAttribute("urljoin", "urlparse", "urllib.parse"),
+    MovedAttribute("urlparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("quote", "urllib", "urllib.parse"),
+    MovedAttribute("quote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
+    MovedAttribute("urlencode", "urllib", "urllib.parse"),
+    MovedAttribute("splitquery", "urllib", "urllib.parse"),
+    MovedAttribute("splittag", "urllib", "urllib.parse"),
+    MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("splitvalue", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
+]
+for attr in _urllib_parse_moved_attributes:
+    setattr(Module_six_moves_urllib_parse, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
+                      "moves.urllib_parse", "moves.urllib.parse")
+
+
+class Module_six_moves_urllib_error(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_error"""
+
+
+_urllib_error_moved_attributes = [
+    MovedAttribute("URLError", "urllib2", "urllib.error"),
+    MovedAttribute("HTTPError", "urllib2", "urllib.error"),
+    MovedAttribute("ContentTooShortError", "urllib", "urllib.error"),
+]
+for attr in _urllib_error_moved_attributes:
+    setattr(Module_six_moves_urllib_error, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
+                      "moves.urllib_error", "moves.urllib.error")
+
+
+class Module_six_moves_urllib_request(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_request"""
+
+
+_urllib_request_moved_attributes = [
+    MovedAttribute("urlopen", "urllib2", "urllib.request"),
+    MovedAttribute("install_opener", "urllib2", "urllib.request"),
+    MovedAttribute("build_opener", "urllib2", "urllib.request"),
+    MovedAttribute("pathname2url", "urllib", "urllib.request"),
+    MovedAttribute("url2pathname", "urllib", "urllib.request"),
+    MovedAttribute("getproxies", "urllib", "urllib.request"),
+    MovedAttribute("Request", "urllib2", "urllib.request"),
+    MovedAttribute("OpenerDirector", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDefaultErrorHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPRedirectHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPCookieProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
+    MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPSHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FileHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("CacheFTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("UnknownHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("urlretrieve", "urllib", "urllib.request"),
+    MovedAttribute("urlcleanup", "urllib", "urllib.request"),
+    MovedAttribute("URLopener", "urllib", "urllib.request"),
+    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+    MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
+]
+for attr in _urllib_request_moved_attributes:
+    setattr(Module_six_moves_urllib_request, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
+                      "moves.urllib_request", "moves.urllib.request")
+
+
+class Module_six_moves_urllib_response(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_response"""
+
+
+_urllib_response_moved_attributes = [
+    MovedAttribute("addbase", "urllib", "urllib.response"),
+    MovedAttribute("addclosehook", "urllib", "urllib.response"),
+    MovedAttribute("addinfo", "urllib", "urllib.response"),
+    MovedAttribute("addinfourl", "urllib", "urllib.response"),
+]
+for attr in _urllib_response_moved_attributes:
+    setattr(Module_six_moves_urllib_response, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
+                      "moves.urllib_response", "moves.urllib.response")
+
+
+class Module_six_moves_urllib_robotparser(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_robotparser"""
+
+
+_urllib_robotparser_moved_attributes = [
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
+]
+for attr in _urllib_robotparser_moved_attributes:
+    setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
+                      "moves.urllib_robotparser", "moves.urllib.robotparser")
+
+
+class Module_six_moves_urllib(types.ModuleType):
+
+    """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
+    __path__ = []  # mark as package
+    parse = _importer._get_module("moves.urllib_parse")
+    error = _importer._get_module("moves.urllib_error")
+    request = _importer._get_module("moves.urllib_request")
+    response = _importer._get_module("moves.urllib_response")
+    robotparser = _importer._get_module("moves.urllib_robotparser")
+
+    def __dir__(self):
+        return ['parse', 'error', 'request', 'response', 'robotparser']
+
+_importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
+                      "moves.urllib")
+
+
+def add_move(move):
+    """Add an item to six.moves."""
+    setattr(_MovedItems, move.name, move)
+
+
+def remove_move(name):
+    """Remove item from six.moves."""
+    try:
+        delattr(_MovedItems, name)
+    except AttributeError:
+        try:
+            del moves.__dict__[name]
+        except KeyError:
+            raise AttributeError("no such move, %r" % (name,))
+
+
+if PY3:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
+else:
+    _meth_func = "im_func"
+    _meth_self = "im_self"
+
+    _func_closure = "func_closure"
+    _func_code = "func_code"
+    _func_defaults = "func_defaults"
+    _func_globals = "func_globals"
+
+
+try:
+    advance_iterator = next
+except NameError:
+    def advance_iterator(it):
+        return it.next()
+next = advance_iterator
+
+
+try:
+    callable = callable
+except NameError:
+    def callable(obj):
+        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
+
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+    def create_unbound_method(func, cls):
+        return types.MethodType(func, None, cls)
+
+    class Iterator(object):
+
+        def next(self):
+            return type(self).__next__(self)
+
+    callable = callable
+_add_doc(get_unbound_function,
+         """Get the function out of a possibly unbound function""")
+
+
+get_method_function = operator.attrgetter(_meth_func)
+get_method_self = operator.attrgetter(_meth_self)
+get_function_closure = operator.attrgetter(_func_closure)
+get_function_code = operator.attrgetter(_func_code)
+get_function_defaults = operator.attrgetter(_func_defaults)
+get_function_globals = operator.attrgetter(_func_globals)
+
+
+if PY3:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
+else:
+    def iterkeys(d, **kw):
+        return d.iterkeys(**kw)
+
+    def itervalues(d, **kw):
+        return d.itervalues(**kw)
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+    def iterlists(d, **kw):
+        return d.iterlists(**kw)
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
+
+_add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
+_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
+_add_doc(iteritems,
+         "Return an iterator over the (key, value) pairs of a dictionary.")
+_add_doc(iterlists,
+         "Return an iterator over the (key, [values]) pairs of a dictionary.")
+
+
+if PY3:
+    def b(s):
+        return s.encode("latin-1")
+
+    def u(s):
+        return s
+    unichr = chr
+    import struct
+    int2byte = struct.Struct(">B").pack
+    del struct
+    byte2int = operator.itemgetter(0)
+    indexbytes = operator.getitem
+    iterbytes = iter
+    import io
+    StringIO = io.StringIO
+    BytesIO = io.BytesIO
+    del io
+    _assertCountEqual = "assertCountEqual"
+    if sys.version_info[1] <= 1:
+        _assertRaisesRegex = "assertRaisesRegexp"
+        _assertRegex = "assertRegexpMatches"
+    else:
+        _assertRaisesRegex = "assertRaisesRegex"
+        _assertRegex = "assertRegex"
+else:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+_add_doc(b, """Byte literal""")
+_add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+print_ = getattr(moves.builtins, "print", None)
+if print_ is None:
+    def print_(*args, **kwargs):
+        """The new-style print function for Python 2.4 and 2.5."""
+        fp = kwargs.pop("file", sys.stdout)
+        if fp is None:
+            return
+
+        def write(data):
+            if not isinstance(data, basestring):
+                data = str(data)
+            # If the file has an encoding, encode unicode with it.
+            if (isinstance(fp, file) and
+                    isinstance(data, unicode) and
+                    fp.encoding is not None):
+                errors = getattr(fp, "errors", None)
+                if errors is None:
+                    errors = "strict"
+                data = data.encode(fp.encoding, errors)
+            fp.write(data)
+        want_unicode = False
+        sep = kwargs.pop("sep", None)
+        if sep is not None:
+            if isinstance(sep, unicode):
+                want_unicode = True
+            elif not isinstance(sep, str):
+                raise TypeError("sep must be None or a string")
+        end = kwargs.pop("end", None)
+        if end is not None:
+            if isinstance(end, unicode):
+                want_unicode = True
+            elif not isinstance(end, str):
+                raise TypeError("end must be None or a string")
+        if kwargs:
+            raise TypeError("invalid keyword arguments to print()")
+        if not want_unicode:
+            for arg in args:
+                if isinstance(arg, unicode):
+                    want_unicode = True
+                    break
+        if want_unicode:
+            newline = unicode("\n")
+            space = unicode(" ")
+        else:
+            newline = "\n"
+            space = " "
+        if sep is None:
+            sep = space
+        if end is None:
+            end = newline
+        for i, arg in enumerate(args):
+            if i:
+                write(sep)
+            write(arg)
+        write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
+
+_add_doc(reraise, """Reraise an exception.""")
+
+if sys.version_info[0:2] < (3, 4):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
+        def wrapper(f):
+            f = functools.wraps(wrapped, assigned, updated)(f)
+            f.__wrapped__ = wrapped
+            return f
+        return wrapper
+else:
+    wraps = functools.wraps
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(type):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        if hasattr(cls, '__qualname__'):
+            orig_vars['__qualname__'] = cls.__qualname__
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+
+def ensure_binary(s, encoding='utf-8', errors='strict'):
+    """Coerce **s** to six.binary_type.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> encoded to `bytes`
+      - `bytes` -> `bytes`
+    """
+    if isinstance(s, text_type):
+        return s.encode(encoding, errors)
+    elif isinstance(s, binary_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
+def ensure_str(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to `str`.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if PY2 and isinstance(s, text_type):
+        s = s.encode(encoding, errors)
+    elif PY3 and isinstance(s, binary_type):
+        s = s.decode(encoding, errors)
+    return s
+
+
+def ensure_text(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to six.text_type.
+
+    For Python 2:
+      - `unicode` -> `unicode`
+      - `str` -> `unicode`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    elif isinstance(s, text_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+
+# Complete the moves implementation.
+# This code is at the end of this module to speed up module loading.
+# Turn this module into a package.
+__path__ = []  # required for PEP 302 and PEP 451
+__package__ = __name__  # see PEP 366 @ReservedAssignment
+if globals().get("__spec__") is not None:
+    __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
+# Remove other six meta path importers, since they cause problems. This can
+# happen if six is removed from sys.modules and then reloaded. (Setuptools does
+# this for some reason.)
+if sys.meta_path:
+    for i, importer in enumerate(sys.meta_path):
+        # Here's some real nastiness: Another "instance" of the six module might
+        # be floating around. Therefore, we can't use isinstance() to check for
+        # the six meta path importer, since the other six instance will have
+        # inserted an importer with different class.
+        if (type(importer).__name__ == "_SixMetaPathImporter" and
+                importer.name == __name__):
+            del sys.meta_path[i]
+            break
+    del i, importer
+# Finally, add the importer to the meta path import hook.
+sys.meta_path.append(_importer)

--- a/src/utm2dem.py
+++ b/src/utm2dem.py
@@ -13,10 +13,10 @@ def utm2dem(inDem,outDem,demPar,dataType="float"):
     logname = basename + "_utm_dem.log"
     log = open(logname,"w")
 
-    print "UTM DEM in GEOTIFF format: {}".format(inDem)
-    print "output DEM: {}".format(outDem)
-    print "output DEM parameter file: {}".format(demPar)
-    print "log file: {}".format(logname)
+    print("UTM DEM in GEOTIFF format: {}".format(inDem))
+    print("output DEM: {}".format(outDem))
+    print("output DEM parameter file: {}".format(demPar))
+    print("log file: {}".format(logname))
 
     (x,y,trans,proj,data) = saa.read_gdal_file(saa.open_gdal_file(inDem))
 
@@ -36,32 +36,32 @@ def utm2dem(inDem,outDem,demPar,dataType="float"):
              v = u[2].split(",")
              w = v[1].split("]")
              false_north = w[0]
-    print "found false_north {}".format(false_north)
+    print("found false_north {}".format(false_north))
 
     srs=osr.SpatialReference(wkt=prj)
     string = srs.GetAttrValue('projcs')
     t = string.split(" ")
     zone = t[5]
-    print "Found zone string {} of length {}".format(zone,len(zone))
-    
+    print("Found zone string {} of length {}".format(zone, len(zone)))
+
     if len(zone) == 3:
         zone = zone[0:2]
     else:
         zone = zone[0]
-    print "found zone {}".format(zone)
+    print("found zone {}".format(zone))
 
     src = gdal.Open(inDem, gdalconst.GA_ReadOnly)
     string = src.GetMetadata()
     pixasarea = string["AREA_OR_POINT"]
     if "AREA" in pixasarea:
-        print "Pixel as Area! Updating corner coordinates to pixel as point"
-        print "pixel upper northing (m): {}    easting (m): {}".format(north,east)
+        print("Pixel as Area! Updating corner coordinates to pixel as point")
+        print("pixel upper northing (m): {}    easting (m): {}".format(north, east))
         east = east + pix_east / 2.0
         north = north + pix_north / 2.0
-        print "Update pixel upper northing (m): {}    easting (m): {}".format(north,east)
+        print("Update pixel upper northing (m): {}    easting (m): {}".format(north, east))
 
     pix_size = pix_east
-    print "approximate DEM latitude pixel spacing (m): {}".format(pix_size)
+    print("approximate DEM latitude pixel spacing (m): {}".format(pix_size))
 
     # Create the input file for create_dem_par    
     f = open(demParIn,"w")


### PR DESCRIPTION
As a result of my playing around this week, I found a few unresolved references, which are fixed here. 

The main one of note is in 21e1a94, where an unresolved reference to `inFile` in `par_s1_slc_single.py` prevented the use of precision state vectors. Because it's in a broad try-except block, it would always log a `Unable to fetch precision state vectors` warning and continue without interruption. So this fix should go into production asap, I think. 


Other minor fixes are:
* finished depreciation of `python_data_utils`
* eliminated the  use of mixed spaces and tabs
* ensured all `print` statements were called like a function (for python 3)
* included `six.py` which helps with python 2 and 3 compatibility (e.g., `urlparse` in python 2 has been moved to `urllib.parse` in python 3 and `six` provides a uniform way to import it in both version)

Because I've got my eye on python 3 compatibility, I also cherry-picked a couple of commits from @asjohnston-asf `python3` branch which looked like they should hit production (03b82c1 and abefabd)

@talogan and I walked through this PR at my desk, but I've added him as a review in case he wants to add any comments/request any further changes.

Fixes #104 