### PR TITLE
Remove alpha channel from convert for thumbnails

### DIFF
--- a/src/make_arc_thumb.py
+++ b/src/make_arc_thumb.py
@@ -13,7 +13,7 @@ import os
 def pngtothumb(pngfile):
 
     # Modify the png to a jpg thumbnail, then encode to base64
-    rgb_im = Image.open(pngfile).convert('RGBA')
+    rgb_im = Image.open(pngfile).convert('RGB')
     x, y = rgb_im.size
     if x>y:
         width = 200


### PR DESCRIPTION
Adding the alpha channel raised this error at the end of RTC processing:

2019-11-19 01:24:49,672 [DEBUG] Proc: raise IOError("cannot write mode %s as JPEG" % im.mode)
2019-11-19 01:24:49,672 [DEBUG] Proc: IOError: cannot write mode RGBA as JPEG

when converted to RGB it works as expected.