### PR TITLE
Py3 compatibility

### DIFF
--- a/src/SLC_copy_S1_fullSW.py
+++ b/src/SLC_copy_S1_fullSW.py
@@ -5,9 +5,7 @@ import argparse
 from argparse import RawTextHelpFormatter
 from execute import execute
 from getParameter import getParameter
-import sys, re, os
-import zipfile
-import glob
+import os
 import shutil
 
 def SLC_copy_S1_fullSW(path,slcname,tabin,burst_tab,mode=2,dem=None,dempath=None,raml=10,azml=2):

--- a/src/apply_wb_mask.py
+++ b/src/apply_wb_mask.py
@@ -1,15 +1,13 @@
 #!/usr/bin/python
 
 import os
-import numpy as np
+# import numpy as np
 import scipy.misc
 import argparse
 import logging
-import shutil
 from osgeo import gdal
 from create_wb_mask import create_wb_mask
 import saa_func_lib as saa
-from osgeo.gdalconst import *
 
 def create_wb_mask_file(xmin,ymin,xmax,ymax,res,gcs=True):
 

--- a/src/asf_geometry.py
+++ b/src/asf_geometry.py
@@ -132,7 +132,7 @@ def cut_blackfill(data, geoTrans):
   return (data, colFirst, rowFirst, geoTrans)
 
 
-def geotiff_overlap(firstFile, secondFile, type):
+def geotiff_overlap(firstFile, secondFile, method):
 
   # Check map projections
   raster = gdal.Open(firstFile)
@@ -145,9 +145,9 @@ def geotiff_overlap(firstFile, secondFile, type):
   firstPolygon = geotiff2polygon(firstFile)
   secondPolygon = geotiff2polygon(secondFile)
 
-  if type == 'intersection':
+  if method == 'intersection':
     overlap = firstPolygon.Intersection(secondPolygon)
-  elif type == 'union':
+  elif method == 'union':
     overlap = firstPolygon.Union(secondPolygon)
 
   return (firstPolygon, secondPolygon, overlap, proj, pixelSize)

--- a/src/asf_geometry.py
+++ b/src/asf_geometry.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import csv
-import math
 from osgeo import gdal, ogr, osr
 from scipy import ndimage
 import numpy as np

--- a/src/asf_geometry.py
+++ b/src/asf_geometry.py
@@ -72,7 +72,7 @@ def geotiff2boundary_mask(inGeotiff, tsEPSG, threshold, use_closing=True):
     rowFirst = 0
   else:
     data[np.isnan(data)==True] = noDataValue
-    if threshold != None:
+    if threshold is not None:
       print('Applying threshold ({0}) ...'.format(threshold))
       data[data<np.float(threshold)] = noDataValue
     if noDataValue == np.nan or noDataValue == -np.nan:
@@ -278,9 +278,9 @@ def data_geometry2shape_ext(data, fields, values, spatialRef, geoTrans,
   classes, threshold, background, shapeFile):
 
   # Check input
-  if threshold != None:
+  if threshold is not None:
     threshold = float(threshold)
-  if background != None:
+  if background is not None:
     background = int(background)
 
   # Buffer data
@@ -339,7 +339,7 @@ def data_geometry2shape_ext(data, fields, values, spatialRef, geoTrans,
     fill = False
     if cValue == 0:
       fill = True
-    if background != None and cValue == background:
+    if background is not None and cValue == background:
       fill = True
     geometry = outFeature.GetGeometryRef()
     area = float(geometry.GetArea())
@@ -691,7 +691,7 @@ def geotiff2boundary_ext(inGeotiff, maskFile, geographic):
   (rows, cols) = data.shape
 
   # Save in mask file (if defined)
-  if maskFile != None:
+  if maskFile is not None:
     gdalDriver = gdal.GetDriverByName('GTiff')
     outRaster = gdalDriver.Create(maskFile, rows, cols, 1, gdal.GDT_Byte)
     outRaster.SetGeoTransform(geoTrans)

--- a/src/copy_metadata.py
+++ b/src/copy_metadata.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 
-import os
 import argparse
 import saa_func_lib as saa
-import shutil
 from osgeo import gdal
 
 def copy_metadata(infile, outfile):
@@ -11,12 +9,12 @@ def copy_metadata(infile, outfile):
     md = ds.GetMetadata()
     print(md)
 
-    #    ds = saa.open_gdal_file(outfile)
-#    ds.SetMetadata(md)
+    # ds = saa.open_gdal_file(outfile)
+    # ds.SetMetadata(md)
 
-    outfile2 = "tmp_outfile.tif"
-#    gdal.Translate(outfile2,outfile, metadataOptions = md)
-#    shutil.move(outfile2,outfile)
+    # outfile2 = "tmp_outfile.tif"
+    # gdal.Translate(outfile2,outfile, metadataOptions = md)
+    # shutil.move(outfile2,outfile)
 
 
     ds = saa.open_gdal_file(outfile)

--- a/src/createAmp.py
+++ b/src/createAmp.py
@@ -2,7 +2,6 @@
 
 import saa_func_lib as saa
 import numpy as np
-import sys, os, re
 import argparse
 
 def createAmp(fi,nodata=None):

--- a/src/create_wb_mask.py
+++ b/src/create_wb_mask.py
@@ -1,13 +1,10 @@
 #!/usr/bin/python
 
 import os
-import numpy as np
 import logging
-import argparse
 from osgeo import gdal
 from osgeo import ogr
 import scipy.misc
-import saa_func_lib as saa
 
 def create_wb_mask(shpfile,xmin,ymin,xmax,ymax,res,outFile=None,mask=1,gcs=True):
     

--- a/src/dem2isce.py
+++ b/src/dem2isce.py
@@ -25,76 +25,76 @@ def dem2isce(demFile, hdrFile, xmlFile):
 
   # Build XML tree
   isce = et.Element('component', name='DEM')
-  property = et.SubElement(isce, 'property', name='BYTE_ORDER')
+  element_property = et.SubElement(isce, 'property', name='BYTE_ORDER')
   if 'byte order = 0' in lines:
-    et.SubElement(property, 'value').text = 'l'
+    et.SubElement(element_property, 'value').text = 'l'
   else:
-    et.SubElement(property, 'value').text = 'b'
-  property = et.SubElement(isce, 'property', name='ACCESS_MODE')
-  et.SubElement(property, 'value').text = 'read'
-  property = et.SubElement(isce, 'property', name='REFERENCE')
+    et.SubElement(element_property, 'value').text = 'b'
+  element_property = et.SubElement(isce, 'property', name='ACCESS_MODE')
+  et.SubElement(element_property, 'value').text = 'read'
+  element_property = et.SubElement(isce, 'property', name='REFERENCE')
   if datum == 'WGS_1984':
-    et.SubElement(property, 'value').text = 'WGS84'
+    et.SubElement(element_property, 'value').text = 'WGS84'
   elif datum == 'North_American_Datum_1983':
-    et.SubElement(property, 'value').text = 'NAD83'
-  property = et.SubElement(isce, 'property', name='DATA_TYPE')
+    et.SubElement(element_property, 'value').text = 'NAD83'
+  element_property = et.SubElement(isce, 'property', name='DATA_TYPE')
   if data_type == 'Int16':
-    et.SubElement(property, 'value').text = 'SHORT'
+    et.SubElement(element_property, 'value').text = 'SHORT'
   elif data_type == 'Float32':
-    et.SubElement(property, 'value').text = 'FLOAT'
-  property = et.SubElement(isce, 'property', name='SCHEME')
+    et.SubElement(element_property, 'value').text = 'FLOAT'
+  element_property = et.SubElement(isce, 'property', name='SCHEME')
   if 'interleave = bsq' in lines:
-    et.SubElement(property, 'value').text = 'BSQ'
+    et.SubElement(element_property, 'value').text = 'BSQ'
   elif 'interleave = bil' in lines:
-    et.SubElement(property, 'value').text = 'BIL'
+    et.SubElement(element_property, 'value').text = 'BIL'
   elif 'interleave = bip' in lines:
-    et.SubElement(property, 'value').text = 'BIP'
-  property = et.SubElement(isce, 'property', name='IMAGE_TYPE')
-  et.SubElement(property, 'value').text = 'dem'
-  property = et.SubElement(isce, 'property', name='FILE_NAME')
-  et.SubElement(property, 'value').text = os.path.abspath(demFile)
-  property = et.SubElement(isce, 'property', name='WIDTH')
-  et.SubElement(property, 'value').text = str(raster.RasterXSize)
-  property = et.SubElement(isce, 'property', name='LENGTH')
-  et.SubElement(property, 'value').text = str(raster.RasterYSize)
-  property = et.SubElement(isce, 'property', name='NUMBER_BANDS')
-  et.SubElement(property, 'value').text = str(raster.RasterCount)
-  property = et.SubElement(isce, 'property', name='FIRST_LATITUDE')  
-  et.SubElement(property, 'value').text = str(gt[3])
-  property = et.SubElement(isce, 'property', name='FIRST_LONGITUDE')
-  et.SubElement(property, 'value').text = str(gt[0])
-  property = et.SubElement(isce, 'property', name='DELTA_LATITUDE')
-  et.SubElement(property, 'value').text = str(gt[5])
-  property = et.SubElement(isce, 'property', name='DELTA_LONGITUDE')
-  et.SubElement(property, 'value').text = str(gt[1])
+    et.SubElement(element_property, 'value').text = 'BIP'
+  element_property = et.SubElement(isce, 'property', name='IMAGE_TYPE')
+  et.SubElement(element_property, 'value').text = 'dem'
+  element_property = et.SubElement(isce, 'property', name='FILE_NAME')
+  et.SubElement(element_property, 'value').text = os.path.abspath(demFile)
+  element_property = et.SubElement(isce, 'property', name='WIDTH')
+  et.SubElement(element_property, 'value').text = str(raster.RasterXSize)
+  element_property = et.SubElement(isce, 'property', name='LENGTH')
+  et.SubElement(element_property, 'value').text = str(raster.RasterYSize)
+  element_property = et.SubElement(isce, 'property', name='NUMBER_BANDS')
+  et.SubElement(element_property, 'value').text = str(raster.RasterCount)
+  element_property = et.SubElement(isce, 'property', name='FIRST_LATITUDE')
+  et.SubElement(element_property, 'value').text = str(gt[3])
+  element_property = et.SubElement(isce, 'property', name='FIRST_LONGITUDE')
+  et.SubElement(element_property, 'value').text = str(gt[0])
+  element_property = et.SubElement(isce, 'property', name='DELTA_LATITUDE')
+  et.SubElement(element_property, 'value').text = str(gt[5])
+  element_property = et.SubElement(isce, 'property', name='DELTA_LONGITUDE')
+  et.SubElement(element_property, 'value').text = str(gt[1])
   component = et.SubElement(isce, 'component', name='Coordinate1')
   et.SubElement(component, 'factorymodule').text = 'isceobj.Image'
   et.SubElement(component, 'factoryname').text = 'createCoordinate'
   et.SubElement(component, 'doc').text = 'First coordinate of a 2D image (width).'
-  property = et.SubElement(component, 'property', name='startingValue')
-  et.SubElement(property, 'value').text = str(gt[0])
-  et.SubElement(property, 'doc').text = 'Starting value of the coordinate.'
-  et.SubElement(property, 'units').text = 'degree'
-  property = et.SubElement(component, 'property', name='delta')
-  et.SubElement(property, 'value').text = str(gt[1])
-  et.SubElement(property, 'doc').text = 'Coordinate quantization.'
-  property = et.SubElement(component, 'property', name='size')
-  et.SubElement(property, 'value').text = str(raster.RasterXSize)
-  et.SubElement(property, 'doc').text = 'Coordinate size.'
+  element_property = et.SubElement(component, 'property', name='startingValue')
+  et.SubElement(element_property, 'value').text = str(gt[0])
+  et.SubElement(element_property, 'doc').text = 'Starting value of the coordinate.'
+  et.SubElement(element_property, 'units').text = 'degree'
+  element_property = et.SubElement(component, 'property', name='delta')
+  et.SubElement(element_property, 'value').text = str(gt[1])
+  et.SubElement(element_property, 'doc').text = 'Coordinate quantization.'
+  element_property = et.SubElement(component, 'property', name='size')
+  et.SubElement(element_property, 'value').text = str(raster.RasterXSize)
+  et.SubElement(element_property, 'doc').text = 'Coordinate size.'
   component = et.SubElement(isce, 'component', name='Coordinate2')
   et.SubElement(component, 'factorymodule').text = 'isceobj.Image'
   et.SubElement(component, 'factoryname').text = 'createCoordinate'
   et.SubElement(component, 'doc').text = 'Second coordinate of a 2D image (length).'
-  property = et.SubElement(component, 'property', name='startingValue')
-  et.SubElement(property, 'value').text = str(gt[3])
-  et.SubElement(property, 'doc').text = 'Starting value of the coordinate.'
-  et.SubElement(property, 'units').text = 'degree'
-  property = et.SubElement(component, 'property', name='delta')
-  et.SubElement(property, 'value').text = str(gt[5])
-  et.SubElement(property, 'doc').text = 'Coordinate quantization.'
-  property = et.SubElement(component, 'property', name='size')
-  et.SubElement(property, 'value').text = str(raster.RasterYSize)
-  et.SubElement(property, 'doc').text = 'Coordinate size.'
+  element_property = et.SubElement(component, 'property', name='startingValue')
+  et.SubElement(element_property, 'value').text = str(gt[3])
+  et.SubElement(element_property, 'doc').text = 'Starting value of the coordinate.'
+  et.SubElement(element_property, 'units').text = 'degree'
+  element_property = et.SubElement(component, 'property', name='delta')
+  et.SubElement(element_property, 'value').text = str(gt[5])
+  et.SubElement(element_property, 'doc').text = 'Coordinate quantization.'
+  element_property = et.SubElement(component, 'property', name='size')
+  et.SubElement(element_property, 'value').text = str(raster.RasterYSize)
+  et.SubElement(element_property, 'doc').text = 'Coordinate size.'
   
   # Write the tree structure to file
   with open(xmlFile, 'w') as outF:

--- a/src/extendDateline.py
+++ b/src/extendDateline.py
@@ -4,7 +4,7 @@ import argparse
 from argparse import RawTextHelpFormatter
 import os
 import sys
-from osgeo import gdal, ogr, osr
+from osgeo import ogr
 
 
 def extendDateline(inFile, outFile, degrees):

--- a/src/geotiff_lut.py
+++ b/src/geotiff_lut.py
@@ -4,10 +4,8 @@ import argparse
 from argparse import RawTextHelpFormatter
 import os
 import sys
-import lxml.etree as et
 import numpy as np
-from osgeo import gdal, ogr, osr
-from osgeo.gdalconst import *
+from osgeo import gdal, osr
 
 
 def geotiff_lut(geotiff, lutFile, outFile):

--- a/src/getDemFor.py
+++ b/src/getDemFor.py
@@ -32,7 +32,6 @@
 # Import all needed modules right away
 #
 #####################
-from lxml import etree
 import get_dem
 import os
 import sys

--- a/src/getSubSwath.py
+++ b/src/getSubSwath.py
@@ -24,9 +24,7 @@
 # Import all needed modules right away
 #
 #####################
-import sys
 import os
-from lxml import etree
 from osgeo import ogr
 import glob
 from lxml import etree

--- a/src/getSubSwath.py
+++ b/src/getSubSwath.py
@@ -55,15 +55,15 @@ def get_bounding_box_file(safeFile):
     lon_min = min(lon1,lon2,lon3,lon4)
 
     if (lon_min <= -177 and lon_max>177):
-        lat_max = lat_max - 0.15;
-        lat_min = lat_min + 0.15;
-        lon_max = lon_max - 0.15;
-        lon_min = lon_min + 0.15;
+        lat_max = lat_max - 0.15
+        lat_min = lat_min + 0.15
+        lon_max = lon_max - 0.15
+        lon_min = lon_min + 0.15
     else:
-        lat_max = lat_max + 0.15;
-        lat_min = lat_min - 0.15;
-        lon_max = lon_max + 0.15;
-        lon_min = lon_min - 0.15;
+        lat_max = lat_max + 0.15
+        lat_min = lat_min - 0.15
+        lon_max = lon_max + 0.15
+        lon_min = lon_min - 0.15
 
     return lat_max,lat_min,lon_max,lon_min
 

--- a/src/get_bb_from_shape.py
+++ b/src/get_bb_from_shape.py
@@ -1,14 +1,6 @@
 #!/usr/bin/python
 
-import argparse
-from argparse import RawTextHelpFormatter
-import os
-import sys
-import datetime
-import logging
-import numpy as np
-from osgeo import gdal, ogr, osr
-import shutil
+from osgeo import ogr
 
 def get_bb_from_shape(shapeFile):
 
@@ -17,7 +9,7 @@ def get_bb_from_shape(shapeFile):
   shape = driver.Open(shapeFile, 0)
   vectorMultipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
   layer = shape.GetLayer()
-  vectorSpatialRef = layer.GetSpatialRef()
+  # vectorSpatialRef = layer.GetSpatialRef()
 
   # Reproject polygon if necessary
   # if vectorSpatialRef != rasterSpatialRef:

--- a/src/get_dem.py
+++ b/src/get_dem.py
@@ -182,10 +182,10 @@ def handle_anti_meridian(lat_min,lat_max,lon_min,lon_max,outfile):
     logging.info("Handling using anti-meridian special code")
     if (lat_min>49 and lat_max<54):
         logging.info("DEM will be SRTMUS1")
-        anti_meridian_kludge("SRTMUS1_zone1.tif","SRTMUS1","",lat_min,lat_max,lon_min,lon_max,outfile);
+        anti_meridian_kludge("SRTMUS1_zone1.tif","SRTMUS1","",lat_min,lat_max,lon_min,lon_max,outfile)
     elif (lat_min>-52 and lat_max<-6):
         logging.info("DEM will be SRTMGL3")
-        anti_meridian_kludge("SRTMGL3_zone1.tif","SRTMGL3","+south",lat_min,lat_max,lon_min,lon_max,outfile);
+        anti_meridian_kludge("SRTMGL3_zone1.tif","SRTMGL3","+south",lat_min,lat_max,lon_min,lon_max,outfile)
     else:
         logging.error("ERROR: Unable to find a DEM")
         sys.exit(1)

--- a/src/get_orb.py
+++ b/src/get_orb.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import re
-import requests
 from lxml import html
 import os
 from datetime import datetime, timedelta
@@ -9,7 +8,7 @@ import sys
 import argparse
 import requests
 from requests.adapters import HTTPAdapter
-from six.moves.urllib import parse as urlparse
+from six.moves.urllib.parse import urlparse
 
 
 class FileException(Exception):

--- a/src/get_orb.py
+++ b/src/get_orb.py
@@ -98,7 +98,7 @@ def getOrbitFileESA(dataFile):
         orbitFile = findOrbFile(plat, st, files)
         if len(orbitFile) > 0:
           url = restituted+orbitFile
-          break;
+          break
   if len(orbitFile) == 0:
     error = 'Could not find orbit file on ESA website'
     raise FileException(error)

--- a/src/iscegeo2geotif.py
+++ b/src/iscegeo2geotif.py
@@ -26,13 +26,10 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 ###############################################################################
-import sys
 import os
-import re
 import zipfile
 import shutil
 from lxml import etree
-import numpy as np
 from osgeo import gdal
 from execute import execute
 import argparse

--- a/src/makeKml.py
+++ b/src/makeKml.py
@@ -5,8 +5,7 @@ from argparse import RawTextHelpFormatter
 import os
 import sys
 import lxml.etree as et
-from osgeo import gdal, ogr, osr
-from osgeo.gdalconst import *
+from osgeo import gdal
 import zipfile
 
 

--- a/src/offset_xml.py
+++ b/src/offset_xml.py
@@ -3,7 +3,6 @@
 import argparse
 from argparse import RawTextHelpFormatter
 import sys
-import os
 from lxml import etree as et
 
 ns_gmd = {'gmd' : 'http://www.isotc211.org/2005/gmd'}

--- a/src/par_s1_slc_single.py
+++ b/src/par_s1_slc_single.py
@@ -5,10 +5,8 @@ import argparse
 from argparse import RawTextHelpFormatter
 from execute import execute
 from getParameter import getParameter
-import sys, re, os
-import zipfile
+import os
 import glob
-import shutil
 from get_orb import getOrbFile
 
 #

--- a/src/rasterMask.py
+++ b/src/rasterMask.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
 
 import argparse
-import os, sys
+import sys
 import numpy as np
-from osgeo import gdal, ogr, osr
-from asf_geometry import geotiff2data, data2geotiff, raster_meta
+from osgeo import gdal
+from asf_geometry import geotiff2data, data2geotiff
 from asf_time_series import vector_meta
 
 

--- a/src/raster_boundary2shape.py
+++ b/src/raster_boundary2shape.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python
+import os
+import sys
 import argparse
 from argparse import RawTextHelpFormatter
-import os
-from osgeo import gdal, ogr, osr
-import sys
-from asf_geometry import *
+from scipy import ndimage
+from osgeo import ogr
+from asf_geometry import raster_meta, geotiff2boundary_mask, data_geometry2shape
 
 # from asf_time_series import raster_metadata
  

--- a/src/resample_geotiff.py
+++ b/src/resample_geotiff.py
@@ -6,8 +6,8 @@ import os
 import sys
 import math
 import lxml.etree as et
-from osgeo import gdal, ogr, osr
-from osgeo.gdalconst import *
+from osgeo import gdal
+from osgeo.gdalconst import GRIORA_Cubic, GRIORA_NearestNeighbour
 import zipfile
 import glob
 

--- a/src/resample_geotiff.py
+++ b/src/resample_geotiff.py
@@ -70,7 +70,7 @@ def resample_geotiff(geotiff, width, outFormat, outFile, use_nn = False):
   if outFormat.upper() == 'GEOTIFF':
     gdal.Translate(outFile, raster, resampleAlg=resampleMethod, width=width)
   elif outFormat.upper() == 'JPEG' or outFormat.upper() == 'JPG':
-    if colorTable is not None:
+    if colorTable is None:
       gdal.Translate(outFile, raster, format='JPEG', resampleAlg=resampleMethod,
         width=width)
     else:
@@ -90,7 +90,7 @@ def resample_geotiff(geotiff, width, outFormat, outFile, use_nn = False):
     tmpFile = outFile.replace(orgExt, tmpExt)
     rgbFile = None
     if bandCount == 1:
-      if colorTable is not None:
+      if colorTable is None:
         gdal.Warp(tmpFile, raster, resampleAlg=GRIORA_Cubic, width=width,
           srcNodata='0', dstSRS='EPSG:4326', dstAlpha=True)
       else:

--- a/src/resample_geotiff.py
+++ b/src/resample_geotiff.py
@@ -70,7 +70,7 @@ def resample_geotiff(geotiff, width, outFormat, outFile, use_nn = False):
   if outFormat.upper() == 'GEOTIFF':
     gdal.Translate(outFile, raster, resampleAlg=resampleMethod, width=width)
   elif outFormat.upper() == 'JPEG' or outFormat.upper() == 'JPG':
-    if colorTable == None:
+    if colorTable is not None:
       gdal.Translate(outFile, raster, format='JPEG', resampleAlg=resampleMethod,
         width=width)
     else:
@@ -90,7 +90,7 @@ def resample_geotiff(geotiff, width, outFormat, outFile, use_nn = False):
     tmpFile = outFile.replace(orgExt, tmpExt)
     rgbFile = None
     if bandCount == 1:
-      if colorTable == None:
+      if colorTable is not None:
         gdal.Warp(tmpFile, raster, resampleAlg=GRIORA_Cubic, width=width,
           srcNodata='0', dstSRS='EPSG:4326', dstAlpha=True)
       else:

--- a/src/rtc2color.py
+++ b/src/rtc2color.py
@@ -2,12 +2,9 @@
 
 import argparse
 from argparse import RawTextHelpFormatter
-import os
 import sys
-import datetime
-import logging
 import numpy as np
-from osgeo import gdal, ogr, osr
+from osgeo import gdal, osr
 
 
 def rtc2color(fullpolFile, crosspolFile, threshold, geotiff, cleanup=False,

--- a/src/rtc2colordiff.py
+++ b/src/rtc2colordiff.py
@@ -188,10 +188,10 @@ def rtc2colordiff(preFullpol, preCrosspol, postFullpol, postCrosspol, threshold,
   postGreen = postGreen[yPostOff:yPostEnd, xPostOff:xPostEnd]
   preMask = (preGreen > 0).astype(int)
   postMask = (postGreen > 0).astype(int)
-  mask = preMask*postMask;
-  red = postRed*255*mask;
-  green = postGreen*255*mask;
-  blue = 5.0*(postGreen - preGreen)*255*mask;
+  mask = preMask*postMask
+  red = postRed*255*mask
+  green = postGreen*255*mask
+  blue = 5.0*(postGreen - preGreen)*255*mask
 
   # Write output GeoTIFF
   print('Writing color difference image to GeoTIFF (%s)' % geotiff)

--- a/src/rtc2colordiff.py
+++ b/src/rtc2colordiff.py
@@ -1,14 +1,12 @@
 #!/usr/bin/python
 
-import argparse
-from argparse import RawTextHelpFormatter
 import os
 import sys
-import time
+import argparse
+from argparse import RawTextHelpFormatter
 import datetime
-import shutil
-from osgeo import gdal, ogr, osr
-from asf_geometry import *
+from osgeo import gdal, osr
+from asf_geometry import geotiff2polygon, overlap_indices, geotiff_overlap
 from rtc2color import rtc2color
 from execute import execute
 

--- a/src/saa_func_lib.py
+++ b/src/saa_func_lib.py
@@ -43,10 +43,7 @@
 
 from osgeo import gdal
 import numpy as np
-import os
-import sys
 import math
-import xml.dom.minidom
 
 #####################
 #

--- a/src/saa_func_lib.py
+++ b/src/saa_func_lib.py
@@ -126,7 +126,7 @@ def getPixSize(fi):
 
 # Get the UTM zone
 def get_zone(lon_min,lon_max):
-    center_lon = (lon_min+lon_max)/2;
+    center_lon = (lon_min+lon_max)/2
     zf = (center_lon+180)/6+1
     zone = math.floor(zf)
     return zone

--- a/src/subset_geotiff_shape.py
+++ b/src/subset_geotiff_shape.py
@@ -4,8 +4,6 @@ import argparse
 from argparse import RawTextHelpFormatter
 import os
 import sys
-import datetime
-import logging
 import numpy as np
 from osgeo import gdal, ogr, osr
 import shutil


### PR DESCRIPTION
A variety of changes to (mostly) ensure python 3 compatibility and some style fixes. The only thing I haven't done in that regard is to make python 2 behave as if it's python 3 with:

```
from __future__ import print_function, division, unicode_literals, absolute_import
```

See: https://python-future.org/compatible_idioms.html

Major changes in this PR are:
* Fix (my) bad import of urlparse
* Some essential style fixes:
  * Remove `import *`s
  * Remove unused imports
  * Remove all trailing semicolons
  * Don't shadow built-in python functions (fixes some, not all)
  * Use `is` for comparison to `None`