### PR TITLE
bugfix: remove coop DEM location from get_dem.py.cfg

### DIFF
--- a/config/get_dem.py.cfg
+++ b/config/get_dem.py.cfg
@@ -6,4 +6,3 @@ NED2 s3://asf-dem-east/NED2 4269
 GIMP s3://asf-dem-east/GIMP 3413
 REMA s3://asf-dem-east/REMA 3031
 SRTMGL3 s3://asf-dem-east/SRTMGL3 4326
-VISNAV /mnt/coopSB/masks/VISNAV 4326


### PR DESCRIPTION
HyP3 AMIs try and open files associated with this DEM that are missing and crash out. No need to have this listed DEM list for HyP3.