### PR TITLE
Support GAMMA 2019 create_dem_par for Polar Stereo

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Safety analysis of conda environment
         shell: bash -l {0}
         run: |
-          python -m pip freeze | safety check --full-report --stdin
-          conda list --export | awk -F '=' '/^[^#]/ {print $1 "==" $2}' | safety check --full-report --stdin
+          python -m pip freeze | safety check --full-report -i 38264 --stdin
+          conda list --export | awk -F '=' '/^[^#]/ {print $1 "==" $2}' | safety check --full-report  -i 38264 --stdin
 
 
   package:

--- a/hyp3lib/ps2dem.py
+++ b/hyp3lib/ps2dem.py
@@ -1,109 +1,117 @@
-"""Convert a polar stereo geotiff DEM into GAMMA internal format"""
-
-from __future__ import print_function, absolute_import, division, unicode_literals
+"""Convert a polar stereo GeoTIFF DEM into GAMMA's internal format"""
 
 import argparse
-import hyp3lib.saa_func_lib as saa
-import numpy as np
-import os, sys
 import logging
+import os
+import sys
+from pathlib import Path
+from typing import Union
+
+import numpy as np
 from osgeo import gdal, osr
+
+import hyp3lib.saa_func_lib as saa
 from hyp3lib.execute import execute
 
-def ps2dem(inDem,outDem,demPar):
-    demParIn = "dem_par.in"
-    basename = os.path.basename(inDem)
 
-    logging.info("PS DEM in GEOTIFF format: {}".format(inDem))
-    logging.info("output DEM: {}".format(outDem))
-    logging.info("output DEM parameter file: {}".format(demPar))
+def ps2dem(in_dem: Union[str, Path], out_dem: str, dem_par: str):
+    """
+    Convert a polar stereo GeoTIFF DEM into GAMMA's internal format
 
-    xsize,ysize,trans,proj,data = saa.read_gdal_file(saa.open_gdal_file(inDem))
+    Args:
+        in_dem: Polar stereographic DEM in GeoTIFF to be converted
+        out_dem: Name of the output DEM in GAMMA's internal format
+        dem_par: Name of the output DEM parameter file
+    """
+    dem_par_in = "dem_par.in"
+    basename = os.path.basename(in_dem)
+
+    logging.info("PS DEM in GEOTIFF format: {}".format(in_dem))
+    logging.info("output DEM: {}".format(out_dem))
+    logging.info("output DEM parameter file: {}".format(dem_par))
+
+    xsize, ysize, trans, proj, data = saa.read_gdal_file(saa.open_gdal_file(in_dem))
 
     east = trans[0]
     north = trans[3]
     pix_east = trans[1]
     pix_north = trans[5]
 
-    # Open DEM file
-    src_ds=gdal.Open(inDem)
+    src_ds = gdal.Open(in_dem)
 
-    # Get projection parameters
-    prj=src_ds.GetProjection()
+    prj = src_ds.GetProjection()
 
-    srs=osr.SpatialReference(wkt=prj)
+    srs = osr.SpatialReference(wkt=prj)
     lat_of_origin = srs.GetProjParm("latitude_of_origin")
     central_meridian = srs.GetProjParm("central_meridian")
-   
+
     s = prj.split("[")
     for t in s:
         if "false_northing" in t:
-             u = t.split('"')
-             v = u[2].split(",")
-             w = v[1].split("]")
-             false_north = w[0]
+            u = t.split('"')
+            v = u[2].split(",")
+            w = v[1].split("]")
+            false_north = w[0]
+            logging.info("found false_north {}".format(false_north))
 
     logging.info("latitude of origin {}".format(lat_of_origin))
     logging.info("central_meridian   {}".format(central_meridian))
-    logging.info("found false_north {}".format(false_north))
 
     string = src_ds.GetMetadata()
     pixasarea = string["AREA_OR_POINT"]
     if "AREA" in pixasarea:
         logging.info("Pixel as Area! Updating corner coordinates to pixel as point")
-        logging.info("pixel upper northing (m): {}    easting (m): {}".format(north,east))
+        logging.info("pixel upper northing (m): {}    easting (m): {}".format(north, east))
         east = east + pix_east / 2.0
         north = north + pix_north / 2.0
-        logging.info("Update pixel upper northing (m): {}    easting (m): {}".format(north,east))
+        logging.info("Update pixel upper northing (m): {}    easting (m): {}".format(north, east))
 
-    # Create the input file for create_dem_par    
-    f = open(demParIn,"w")
-    f.write("PS\n")
-    f.write("WGS84\n")
-    f.write("1\n")
-    f.write("{}\n".format(lat_of_origin))
-    f.write("{}\n".format(central_meridian))
-    f.write("{}\n".format(basename))
-    f.write("REAL*4\n")
-    f.write("0\n")
-    f.write("1\n")
-    f.write("{}\n".format(np.abs(xsize)))
-    f.write("{}\n".format(np.abs(ysize)))
-    f.write("{} {}\n".format(pix_north,pix_east))
-    f.write("{} {}\n".format(north,east))
-    f.close()
+    with open(dem_par_in, "w") as f:
+        f.write("PS\n")
+        f.write("WGS84\n")
+        f.write("1\n")
+        f.write(f"{lat_of_origin}\n")
+        f.write(f"{central_meridian}\n")
+        f.write(f"{basename}\n")
+        f.write("REAL*4\n")
+        f.write("0\n")
+        f.write("1\n")
+        f.write(f"{np.abs(xsize)}\n")
+        f.write(f"{np.abs(ysize)}\n")
+        f.write(f"{pix_north} {pix_east}\n")
+        f.write(f"{north} {east}\n")
 
-    # Create a new dem par file
-    if os.path.isfile(demPar): 
-        os.remove(demPar)
-    execute("create_dem_par {} < {}".format(demPar,demParIn))
-    os.remove(demParIn)
+    if os.path.isfile(dem_par):
+        os.remove(dem_par)
+    execute("create_dem_par {} < {}".format(dem_par, dem_par_in))
+    os.remove(dem_par_in)
 
     # Since 0 is the invalid pixel sentinel for gamma software,
-    # Replace 0 with 1, because zero in a DEM is assumed valid 
+    # Replace 0 with 1, because zero in a DEM is assumed valid
     # Then, replace anything <= -32767 with 0
     # (but first remove NANs)
-    srcband = src_ds.GetRasterBand(1) 
-    noData = srcband.GetNoDataValue() 
+    srcband = src_ds.GetRasterBand(1)
+    no_data = srcband.GetNoDataValue()
 
-    data[np.isnan(data)]=0.0001
-    data[data==0] = 1
-    data[data<=noData] = 0
-    
+    data[np.isnan(data)] = 0.0001
+    data[data == 0] = 1
+    data[data <= no_data] = 0
+
     # Convert to ENVI (binary) format
-    tmptif = "temporary_dem_file.tif"
     if data.dtype == np.float32:
         fdata = data
     else:
         # Convert to floating point
         fdata = data.astype(np.float32)
     fdata = fdata.byteswap()
-    saa.write_gdal_file_float(tmptif,trans,proj,fdata)
-    gdal.Translate(outDem,tmptif,format="ENVI")
+
+    tmptif = "temporary_dem_file.tif"
+    saa.write_gdal_file_float(tmptif, trans, proj, fdata)
+    gdal.Translate(out_dem, tmptif, format="ENVI")
     os.remove(tmptif)
-    os.remove(outDem + ".aux.xml")
-    filename, file_extension = os.path.splitext(outDem)
-    os.remove(outDem.replace(file_extension,".hdr"))
+    os.remove(out_dem + ".aux.xml")
+    filename, file_extension = os.path.splitext(out_dem)
+    os.remove(out_dem.replace(file_extension, ".hdr"))
 
 
 def main():
@@ -117,8 +125,8 @@ def main():
     parser.add_argument('dem', help='DEM data (output)')
     parser.add_argument('dempar', help='Gamma DEM parameter file (output)')
 
-    logFile = "{}_{}_log.txt".format("ps2dem", os.getpid())
-    logging.basicConfig(filename=logFile, format='%(asctime)s - %(levelname)s - %(message)s',
+    log_file = "{}_{}_log.txt".format("ps2dem", os.getpid())
+    logging.basicConfig(filename=log_file, format='%(asctime)s - %(levelname)s - %(message)s',
                         datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.DEBUG)
     logging.getLogger().addHandler(logging.StreamHandler())
     logging.info("Starting run")


### PR DESCRIPTION
RTC GAMMA processes on Polar Stereo DEMs fail with a `MemoryError` because `create_dem_par` in GAMMA 2019 has a different interactive UI for polar stereo grids than GAMMA 2017.

We fill of the interactive promps via

```
create_dem_par [FILE] < dem_par.in
```
which will *now* create a `dem_par.in` file for the 2019 UI if `gamma_version` returns *not* GAMMA 2017. 

---
Also, in d962d5b, I:
* fixed all linting errors in `ps2dem.py`
* Added a docstring and type hinting for `ps2dem`

---
Note: UTM has the same promps, so `utm2dem.py` doesn't also need to be updated. 