### PR TITLE
Update hyp3lib.execute to raise a custom exception

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Safety analysis of conda environment
         shell: bash -l {0}
         run: |
+          # Ignore Safety vulerability #38264, GDAL < 3.1, because GAMMA binaries are built against GDAL 2.*
           python -m pip freeze | safety check --full-report -i 38264 --stdin
           conda list --export | awk -F '=' '/^[^#]/ {print $1 "==" $2}' | safety check --full-report  -i 38264 --stdin
 

--- a/hyp3lib/__init__.py
+++ b/hyp3lib/__init__.py
@@ -5,7 +5,7 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 # FIXME: Python 3.8+ this should be `from importlib.metadata...`
 from importlib_metadata import PackageNotFoundError, version
 
-from hyp3lib.exceptions import GranuleError
+from hyp3lib.exceptions import GranuleError, ExecuteError
 
 
 try:
@@ -18,4 +18,4 @@ except PackageNotFoundError:
     #    python setup.py --version
     pass
 
-__all__ = ['__version__', 'GranuleError']
+__all__ = ['__version__', 'GranuleError', 'ExecuteError']

--- a/hyp3lib/exceptions.py
+++ b/hyp3lib/exceptions.py
@@ -3,3 +3,7 @@
 
 class GranuleError(Exception):
     """Error to be raised for incompatible or missing granules"""
+
+
+class ExecuteError(Exception):
+    """Error to be raised when executes (managed subprocesses) fail"""

--- a/hyp3lib/exceptions.py
+++ b/hyp3lib/exceptions.py
@@ -2,5 +2,4 @@
 
 
 class GranuleError(Exception):
-    """Error to be raised for incompatible or missing granlues"""
-
+    """Error to be raised for incompatible or missing granules"""

--- a/hyp3lib/execute.py
+++ b/hyp3lib/execute.py
@@ -1,8 +1,8 @@
 """Managed subprocessing for HyP3 externals"""
 
+import logging
 import os
 import subprocess
-import logging
 from pathlib import Path
 from typing import Optional, TextIO, Union
 
@@ -38,7 +38,7 @@ def execute(cmd: str, expected: Optional[Union[str, Path]] = None, logfile: Opti
         logging.info('subprocess return value was ' + str(return_val))
     else:
         print('subprocess return value was ' + str(return_val))
-    
+
     for line in output.split('\n'):
         if len(line.rstrip()) > 0:
             if uselogging:
@@ -47,7 +47,7 @@ def execute(cmd: str, expected: Optional[Union[str, Path]] = None, logfile: Opti
                 print('Proc: ' + line)
             if logfile is not None:
                 logfile.write("%s\n" % line)
-                
+
     if uselogging:
         logging.info('Finished: ' + cmd)
     else:

--- a/hyp3lib/execute.py
+++ b/hyp3lib/execute.py
@@ -1,8 +1,8 @@
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import os
 import subprocess
 import logging
+
+from hyp3lib import ExecuteError
 
 
 def execute(cmd, expected=None, logfile=None, uselogging=False):
@@ -46,7 +46,7 @@ def execute(cmd, expected=None, logfile=None, uselogging=False):
         for line in output.split('\n'):
             last = line
             if next_line:
-                raise Exception(tool + ': ' + line)
+                raise ExecuteError(tool + ': ' + line)
             elif '** Error: *****' in line:  # MapReady style error
                 next_line = True
             elif 'Error per GCP' in line:  # MapReady message that is NOT an error
@@ -56,9 +56,9 @@ def execute(cmd, expected=None, logfile=None, uselogging=False):
             elif 'Root mean squared error' in line:  # RTC message that is NOT an error
                 pass
             elif 'ERROR' in line.upper():
-                raise Exception(tool + ': ' + line)
+                raise ExecuteError(tool + ': ' + line)
         # No error line found, die with last line
-        raise Exception(tool + ': ' + last)
+        raise ExecuteError(tool + ': ' + last)
 
     if expected is not None:
         if uselogging:
@@ -75,6 +75,6 @@ def execute(cmd, expected=None, logfile=None, uselogging=False):
                 logging.info('Expected output file not found: ' + expected)
             else:
                 print('Expected output file not found: ' + expected)
-            raise Exception("Expected output file not found: " + expected)
+            raise ExecuteError("Expected output file not found: " + expected)
 
     return output

--- a/hyp3lib/execute.py
+++ b/hyp3lib/execute.py
@@ -1,12 +1,30 @@
+"""Managed subprocessing for HyP3 externals"""
+
 import os
 import subprocess
 import logging
+from pathlib import Path
+from typing import Optional, TextIO, Union
 
 from hyp3lib import ExecuteError
 
 
-def execute(cmd, expected=None, logfile=None, uselogging=False):
+def execute(cmd: str, expected: Optional[Union[str, Path]] = None, logfile: Optional[TextIO] = None,
+            uselogging: bool = False) -> str:
+    """
+    Run a command in a subprocess and perform some post-process verification of
+    the command's execution
 
+    Args:
+        cmd: The command to subprocess in a shell
+        expected: Ensure an expected file created by the cmd exists
+        logfile: A file to to write the cmd's stdout to
+        uselogging: Instead of printing status messages of this function, log
+            them with the logging module
+
+    Returns:
+        output: The stdout of cmd
+    """
     if uselogging:
         logging.info('Running command: ' + cmd)
     else:

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,0 +1,49 @@
+import logging
+
+import pytest
+
+from hyp3lib import ExecuteError, execute
+
+
+def test_execute_cmd():
+    cmd = 'echo "Hello world"'
+
+    output = execute.execute(cmd)
+
+    assert 'Hello world' in output
+
+
+def test_excute_cmd_fail():
+    with pytest.raises(ExecuteError):
+        cmd = 'echo "Hello world"; exit 1'
+
+        try:
+            _ = execute.execute(cmd)
+        except ExecuteError as err:
+            assert 'echo' in str(err)
+            raise
+
+
+def test_execute_logfile(tmp_path):
+    cmd = 'echo "Hello world"'
+    log_path = tmp_path / 'echo.log'
+
+    with log_path.open(mode='w') as log_file:
+        output = execute.execute(cmd, logfile=log_file)
+
+        assert 'Hello world' in output
+
+    with log_path.open() as log_file:
+        log_str = log_file.read()
+
+        assert 'Hello world' in log_str
+
+
+def test_execute_uselogging(caplog):
+    with caplog.at_level(logging.INFO):
+        cmd = 'echo "Hello world"'
+
+        output = execute.execute(cmd, uselogging=True)
+
+        assert 'Hello world' in output
+        assert 'Proc: Hello world' in caplog.text


### PR DESCRIPTION
`hyp3lib.execute.execute` previously raised a generic `Exception` when it encounters problems in the executed command. 

This:
* raises a custom `hyp3lib.ExecuteError` exception so that exception handling can be more targeted
* fixes all linting errors in `hyp3lib.execute`
* adds docstrings and typehinting 
* adds some basic tests
* drops unnecessary python2 futures