### PR TITLE
Remove EU, GIMP, REMA DEMs and unused get_dem.py.cfg.aws

### DIFF
--- a/hyp3lib/etc/config/get_dem.py.cfg
+++ b/hyp3lib/etc/config/get_dem.py.cfg
@@ -1,8 +1,5 @@
 NED13 s3://asf-dem-east/NED13 4269
 SRTMGL1 s3://asf-dem-east/SRTMGL1 4326
-EU_DEM_V11 s3://asf-dem-east/EU_DEM_V11 3035
 NED1 s3://asf-dem-east/NED1 4269
 NED2 s3://asf-dem-east/NED2 4269
-GIMP s3://asf-dem-east/GIMP 3413
-REMA s3://asf-dem-east/REMA 3031
 SRTMGL3 s3://asf-dem-east/SRTMGL3 4326

--- a/hyp3lib/etc/config/get_dem.py.cfg.aws
+++ b/hyp3lib/etc/config/get_dem.py.cfg.aws
@@ -1,8 +1,0 @@
-NED13 s3://asf-dem-east/NED13 4269
-EU_DEM_V11 s3://asf-dem-east/EU_DEM_V11 3035
-SRTMGL1 s3://asf-dem-east/SRTMGL1 4326
-NED1 s3://asf-dem-east/NED1 4269
-NED2 s3://asf-dem-east/NED2 4269
-GIMP s3://asf-dem-east/GIMP 3413
-REMA s3://asf-dem-east/REMA 3031
-SRTMGL3 s3://asf-dem-east/SRTMGL3 4326


### PR DESCRIPTION
We're seeing issues related to all three of these DEMs, so remove them from test and production on the containerized processes for now. 

*Note: these will still be available via the **legacy** processes*