### PR TITLE
Better exception handling

### DIFF
--- a/hyp3lib/__init__.py
+++ b/hyp3lib/__init__.py
@@ -6,9 +6,10 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 from importlib_metadata import PackageNotFoundError, version
 
 from hyp3lib.exceptions import (
+    DemError,
+    ExecuteError,
     GeometryError,
     GranuleError,
-    ExecuteError,
 )
 
 try:
@@ -23,7 +24,8 @@ except PackageNotFoundError:
 
 __all__ = [
     '__version__',
+    'DemError',
+    'ExecuteError',
     'GeometryError',
     'GranuleError',
-    'ExecuteError',
 ]

--- a/hyp3lib/__init__.py
+++ b/hyp3lib/__init__.py
@@ -5,8 +5,11 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 # FIXME: Python 3.8+ this should be `from importlib.metadata...`
 from importlib_metadata import PackageNotFoundError, version
 
-from hyp3lib.exceptions import GranuleError, ExecuteError
-
+from hyp3lib.exceptions import (
+    GeometryError,
+    GranuleError,
+    ExecuteError,
+)
 
 try:
     __version__ = version(__name__)
@@ -18,4 +21,9 @@ except PackageNotFoundError:
     #    python setup.py --version
     pass
 
-__all__ = ['__version__', 'GranuleError', 'ExecuteError']
+__all__ = [
+    '__version__',
+    'GeometryError',
+    'GranuleError',
+    'ExecuteError',
+]

--- a/hyp3lib/asf_geometry.py
+++ b/hyp3lib/asf_geometry.py
@@ -1,6 +1,5 @@
 import csv
 import os
-import sys
 
 import numpy as np
 from osgeo import gdal, ogr, osr

--- a/hyp3lib/asf_geometry.py
+++ b/hyp3lib/asf_geometry.py
@@ -1,14 +1,15 @@
-from __future__ import print_function, absolute_import, division, unicode_literals
-
+import csv
 import os
 import sys
-import csv
-from osgeo import gdal, ogr, osr
-from scipy import ndimage
+
 import numpy as np
+from osgeo import gdal, ogr, osr
 from osgeo.gdalconst import GA_ReadOnly
+from scipy import ndimage
+
+from hyp3lib import GeometryError
 from hyp3lib.saa_func_lib import get_zone
-import logging
+
 
 # Determine the boundary polygon of a GeoTIFF file
 def geotiff2polygon_ext(geotiff):
@@ -432,14 +433,10 @@ def spatial_query(source, reference, function):
   # Extract information from tiles and boundary shapefiles
   (geoTile, spatialRef, nameTile) = shape2geometry(reference, 'tile')
   if geoTile is None:
-    logging.error('Could not extract information (tile) out of shapefile (%s)' %
-      reference)
-    sys.exit(1)
+    raise GeometryError(f'Could not extract information (tile) out of shapefile {reference}')
   (boundary, spatialRef, granule) = shape2geometry(source, 'granule')
   if boundary is None:
-    logging.error('Could not extract information (granule) out of shapefile (%s)' %
-      source)
-    sys.exit(1)
+    raise GeometryError(f'Could not extract information (granule) out of shapefile {source}')
 
   # Perform the spatial analysis
   i = 0
@@ -594,8 +591,7 @@ def overlapMask(meta, maskShape, invert, outFile):
   outProj = outLayer.GetSpatialRef()
   outEPSG = int(outProj.GetAttrValue('AUTHORITY', 1))
   if geoEPSG != outEPSG:
-    print('Expecting mask file with EPSG code: {0}'.format(geoEPSG))
-    sys.exit(1)
+    raise GeometryError(f'Expecting mask file with EPSG code: {geoEPSG}')
 
   ### Define re-projection from geographic to UTM
   inProj = osr.SpatialReference()

--- a/hyp3lib/asf_time_series.py
+++ b/hyp3lib/asf_time_series.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import os
 from datetime import datetime, timedelta
 

--- a/hyp3lib/asf_time_series.py
+++ b/hyp3lib/asf_time_series.py
@@ -1,15 +1,17 @@
 from __future__ import print_function, absolute_import, division, unicode_literals
 
 import os
-import sys
 from datetime import datetime, timedelta
+
+import netCDF4 as nc
+import numpy as np
+import statsmodels.api as sm
 from osgeo import gdal, ogr, osr
 from scipy import ndimage
-import numpy as np
-import netCDF4 as nc
-from statsmodels.tsa.seasonal import seasonal_decompose
-import statsmodels.api as sm
 from scipy.interpolate import interp1d
+from statsmodels.tsa.seasonal import seasonal_decompose
+
+from hyp3lib import GeometryError
 from hyp3lib.asf_geometry import geometry_proj2geo, raster_meta
 
 tolerance = 0.00005
@@ -392,8 +394,7 @@ def time_series_slice(ncFile, x, y, typeXY):
   if 'Transverse_Mercator' in var:
     wkt = timeSeries.variables['Transverse_Mercator'].getncattr('crs_wkt')
   else:
-    print('Could not find map projection information!')
-    sys.exit(1)
+    raise GeometryError('Could not find map projection information!')
 
   ### Work out line/sample from various input types
   if typeXY == 'pixel':

--- a/hyp3lib/dem2isce.py
+++ b/hyp3lib/dem2isce.py
@@ -1,10 +1,8 @@
 """generates an XML file for a DEM for ISCE processing"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
 import os
-import sys
+
 import lxml.etree as et
 from osgeo import osr, gdal
 
@@ -14,8 +12,7 @@ def dem2isce(demFile, hdrFile, xmlFile):
   # Read metadata from the DEM
   raster = gdal.Open(demFile, gdal.GA_ReadOnly)
   if raster is None:
-    print('Unable to open DEM file (%s) !' % demFile)
-    sys.exit(1)
+    raise FileNotFoundError(f'Unable to open DEM file {demFile} !')
   print('Converting %s file (%s) ...' % (raster.GetDriver().ShortName, demFile))
   gt = raster.GetGeoTransform()
   band = raster.GetRasterBand(1)

--- a/hyp3lib/exceptions.py
+++ b/hyp3lib/exceptions.py
@@ -1,13 +1,17 @@
 """Custom Exceptions for hyp3lib"""
 
 
+class DemError(Exception):
+    """Error to be raised for incompatible or missing DEMs"""
+
+
+class ExecuteError(Exception):
+    """Error to be raised when executes (managed subprocesses) fail"""
+
+
 class GeometryError(Exception):
     """Error to be raised when geometry/shape manipulation fails"""
 
 
 class GranuleError(Exception):
     """Error to be raised for incompatible or missing granules"""
-
-
-class ExecuteError(Exception):
-    """Error to be raised when executes (managed subprocesses) fail"""

--- a/hyp3lib/exceptions.py
+++ b/hyp3lib/exceptions.py
@@ -1,6 +1,10 @@
 """Custom Exceptions for hyp3lib"""
 
 
+class GeometryError(Exception):
+    """Error to be raised when geometry/shape manipulation fails"""
+
+
 class GranuleError(Exception):
     """Error to be raised for incompatible or missing granules"""
 

--- a/hyp3lib/geotiff_lut.py
+++ b/hyp3lib/geotiff_lut.py
@@ -1,10 +1,8 @@
 """Applies a LUT to a GeoTIFF"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
 import os
-import sys
+
 import numpy as np
 from osgeo import gdal, osr
 
@@ -86,8 +84,7 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.geotiff):
-        print('GeoTIFF file (%s) does not exist!' % args.geotiff)
-        sys.exit(1)
+        parser.error(f'GeoTIFF file {args.geotiff} does not exist!')
 
     geotiff_lut(args.geotiff, args.lut, args.output)
 

--- a/hyp3lib/makeAsfBrowse.py
+++ b/hyp3lib/makeAsfBrowse.py
@@ -1,12 +1,10 @@
 """Resamples a GeoTIFF file and saves it in a number of formats"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
 import os
-import sys
-from hyp3lib.resample_geotiff import resample_geotiff
+
 from hyp3lib import saa_func_lib as saa
+from hyp3lib.resample_geotiff import resample_geotiff
 
 
 def makeAsfBrowse(geotiff, baseName, use_nn=False):
@@ -40,11 +38,9 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.geotiff):
-        print('GeoTIFF file (%s) does not exist!' % args.geotiff)
-        sys.exit(1)
-    if len(os.path.splitext(args.basename)[1]) != 0:
-        print('Output file (%s) has an extension!' % args.basename)
-        sys.exit(1)
+        parser.error(f'GeoTIFF file {args.geotiff} does not exist!')
+    if os.path.splitext(args.basename)[-1]:
+        parser.error(f'Output file {args.basename} has an extension!')
 
     makeAsfBrowse(args.geotiff, args.basename)
 

--- a/hyp3lib/makeChangeBrowse.py
+++ b/hyp3lib/makeChangeBrowse.py
@@ -1,14 +1,13 @@
 """Creates browse images for classified change detection geotiffs"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
-import hyp3lib.saa_func_lib as saa
-import numpy as np
-import sys
 import os
-from hyp3lib.makeAsfBrowse import makeAsfBrowse
+
+import numpy as np
 from osgeo import gdal
+
+import hyp3lib.saa_func_lib as saa
+from hyp3lib.makeAsfBrowse import makeAsfBrowse
 
 MAX_CLASSES = 10
 
@@ -158,8 +157,7 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.geotiff):
-        print('ERROR: GeoTIFF file (%s) does not exist!' % args.geotiff)
-        sys.exit(1)
+        parser.error(f'GeoTIFF file {args.geotiff} does not exist!')
 
     makeChangeBrowse(args.geotiff, type=args.type)
 

--- a/hyp3lib/makeKml.py
+++ b/hyp3lib/makeKml.py
@@ -1,13 +1,11 @@
 """Create a KML file from a geotiff and a png"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
 import os
-import sys
+import zipfile
+
 import lxml.etree as et
 from osgeo import gdal
-import zipfile
 
 
 def makeKML(geotiff,pngFile):
@@ -65,11 +63,9 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.geotiff):
-        print('GeoTIFF file (%s) does not exist!' % args.geotiff)
-        sys.exit(1)
+        parser.error(f'GeoTIFF file {args.geotiff} does not exist!')
     if not os.path.exists(args.pngFile):
-        print('PNG file (%s) does not exist!' % args.pngFile)
-        sys.exit(1)
+        parser.error(f'PNG file {args.pngFile} does not exist!')
 
     makeKML(args.geotiff, args.pngFile)
 

--- a/hyp3lib/make_cogs.py
+++ b/hyp3lib/make_cogs.py
@@ -1,14 +1,12 @@
 """Creates a Cloud Optimized Geotiff from the input geotiff(s)"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
-import shutil
-import os
-import sys
+import argparse
 import glob
 import logging
+import os
+import shutil
+
 from osgeo import gdal
-import argparse
 
 
 def cogify_dir(dir="PRODUCT",debug=False,res=30):
@@ -63,11 +61,9 @@ def main():
 
     for myfile in args.geotiff:
         if not os.path.exists(myfile):
-            print('ERROR: GeoTIFF file (%s) does not exist!' % myfile)
-            sys.exit(1)
+            parser.error(f'GeoTIFF file {myfile} does not exist!')
         if not os.path.splitext(myfile)[1] == '.tif':
-            print('ERRORL Input file (%s) is not geotiff!' % myfile)
-            sys.exit(1)
+            parser.error(f'Input file {myfile} is not a GeoTFF!')
 
         outfile = myfile.replace(".tif", "_cog.tif")
         make_cog(myfile, outfile)

--- a/hyp3lib/ps2dem.py
+++ b/hyp3lib/ps2dem.py
@@ -3,7 +3,6 @@
 import argparse
 import logging
 import os
-import sys
 import warnings
 from pathlib import Path
 from typing import Union
@@ -158,8 +157,7 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.ps_dem):
-        logging.info('ERROR: GeoTIFF file (%s) does not exist!' % args.ps_dem)
-        sys.exit(1)
+        parser.error(f'GeoTIFF file {args.ps_dem} does not exist!')
 
     ps2dem(args.ps_dem, args.dem, args.dempar)
 

--- a/hyp3lib/raster_boundary2shape.py
+++ b/hyp3lib/raster_boundary2shape.py
@@ -1,17 +1,15 @@
 """generates boundary shapefile from GeoTIFF file"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
-import os
-import sys
 import argparse
-from scipy import ndimage
+import os
+
 from osgeo import ogr
+from scipy import ndimage
+
 from hyp3lib.asf_geometry import raster_meta, geotiff2boundary_mask, data_geometry2shape
 
+
 # from hyp3lib.asf_time_series import raster_metadata
-
-
 def raster_metadata(input):
 
   # Set up shapefile attributes
@@ -144,8 +142,7 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.input):
-        print('GeoTIFF file (%s) does not exist!' % args.input)
-        sys.exit(1)
+        parser.error(f'GeoTIFF file {args.input} does not exist!')
 
     raster_boundary2shape(
         args.input, args.threshold, args.shape, args.no_closing, args.fill_holes, args.pixel_shift

--- a/hyp3lib/resample_geotiff.py
+++ b/hyp3lib/resample_geotiff.py
@@ -1,16 +1,14 @@
 """Resamples a GeoTIFF file and saves it in a number of formats"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
-import os
-import sys
+import glob
 import math
+import os
+import zipfile
+
 import lxml.etree as et
 from osgeo import gdal
 from osgeo.gdalconst import GRIORA_Cubic, GRIORA_NearestNeighbour
-import zipfile
-import glob
 
 
 def resample_geotiff(geotiff, width, outFormat, outFile, use_nn = False):
@@ -18,9 +16,7 @@ def resample_geotiff(geotiff, width, outFormat, outFile, use_nn = False):
   # Check output format
   formats = ['GEOTIFF', 'JPEG', 'JPG', 'PNG', 'KML']
   if outFormat.upper() not in formats:
-    print('Unkown output format ({0})!'.format(outFormat.upper()))
-    sys.exit(1)
-
+    raise ValueError(f'Unknown output format ({outFormat.upper()})! Accepted formats: {formats}')
   if use_nn:
       resampleMethod = GRIORA_NearestNeighbour
   else:
@@ -185,11 +181,9 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.geotiff):
-        print('GeoTIFF file (%s) does not exist!' % args.geotiff)
-        sys.exit(1)
-    if len(os.path.splitext(args.output)[1]) == 0:
-        print('Output file (%s) does not have an extension!' % args.output)
-        sys.exit(1)
+        parser.error(f'GeoTIFF file {args.geotiff} does not exist!')
+    if not os.path.splitext(args.output)[-1]:
+        parser.error(f'Output file {args.output} does not have an extension!')
 
     resample_geotiff(args.geotiff, args.width, args.format, args.output)
 

--- a/hyp3lib/simplify_shapefile.py
+++ b/hyp3lib/simplify_shapefile.py
@@ -1,17 +1,15 @@
 """Simplify complicated shapefiles"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
-import glob
-import shutil
-import requests
-import json
 import argparse
+import glob
+import json
 import logging
 import os
-import sys
-from osgeo import osr, ogr
+import shutil
+
+import requests
 import shapefile
+from osgeo import osr, ogr
 
 
 def wkt2shape(wkt,output_file):
@@ -43,8 +41,7 @@ def wkt2shape(wkt,output_file):
 
 def simplify_shapefile(inshp,outshp):
     if not os.path.isfile(inshp):
-        logging.error("ERROR: File {} does not exist".format(inshp))
-        sys.exit(1)
+        raise FileNotFoundError(f"{inshp} does not exist")
     sf = shapefile.Reader(inshp)
     shapes = sf.shapes() 
     scnt = len(shapes)
@@ -62,7 +59,7 @@ def simplify_shapefile(inshp,outshp):
         # post a request for simplification service
         try:
             response = requests.post('https://api.daac.asf.alaska.edu/services/utils/files_to_wkt', files=files)
-        except:
+        except requests.RequestException:
             logging.error("ERROR: service unavaible - it may be that your shapefile is too large.  Reduce to under 300 points")
 
         if not response.status_code == requests.codes.ok:

--- a/hyp3lib/subset_geotiff_shape.py
+++ b/hyp3lib/subset_geotiff_shape.py
@@ -1,13 +1,12 @@
 """Subsets a GeoTIFF file using an AOI from a shapefile"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
 import os
-import sys
+import shutil
+
 import numpy as np
 from osgeo import gdal, ogr, osr
-import shutil
+
 
 def point_within_polygon(x, y, polygon):
 
@@ -154,12 +153,10 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.inGeoTIFF):
-        print('GeoTIFF file (%s) does not exist!' % args.inGeoTIFF)
-        sys.exit(1)
+        parser.error(f'GeoTIFF file {args.inGeoTIFF} does not exist!')
 
     if not os.path.exists(args.shapeFile):
-        print('Shapefile (%s) does not exist!' % args.shapeFile)
-        sys.exit(1)
+        parser.error(f'Shapefile {args.shapeFile} does not exist!')
 
     subset_geotiff_shape(args.inGeoTIFF, args.shapeFile, args.outGeoTIFF)
 

--- a/hyp3lib/tileList2shape.py
+++ b/hyp3lib/tileList2shape.py
@@ -1,11 +1,10 @@
 """generates a shapefile from a list of tile files"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
 import os
-import sys
+
 from osgeo import ogr, osr
+
 from hyp3lib.asf_geometry import geotiff2polygon, geometry2shape
 
 
@@ -50,8 +49,7 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.file_list):
-        print('GeoTIFF file (%s) does not exist!' % args.file_list)
-        sys.exit(1)
+        parser.error(f'GeoTIFF file {args.file_list} does not exist!')
 
     tileList2shape(args.file_list, args.shape_file)
 

--- a/hyp3lib/utm2dem.py
+++ b/hyp3lib/utm2dem.py
@@ -1,13 +1,12 @@
 """Convert a geotiff DEM into GAMMA internal format"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
-import hyp3lib.saa_func_lib as saa
 import os
-import sys
+
 import numpy as np
-from osgeo import gdal,osr,gdalconst
+from osgeo import gdal, osr, gdalconst
+
+import hyp3lib.saa_func_lib as saa
 from hyp3lib.execute import execute
 
 
@@ -125,8 +124,7 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.utm_dem):
-        print('ERROR: GeoTIFF file (%s) does not exist!' % args.utm_dem)
-        sys.exit(1)
+        parser.error(f'GeoTIFF file {args.utm_dem} does not exist!')
 
     utm2dem(args.utm_dem, args.dem, args.dempar, args.dataType)
 

--- a/hyp3lib/verify_opod.py
+++ b/hyp3lib/verify_opod.py
@@ -1,11 +1,8 @@
 """Read OPOD State Vector"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
 import logging
 import os
-import sys
 
 from lxml import etree
 
@@ -16,22 +13,20 @@ def verify_opod(fi):
     check = 0
     for item in root.iter('File_Description'):
         if "Orbit File" not in item.text:
-            logging.error("Not an orbit file!")
-            sys.exit(1)
+            raise ValueError("Not an orbit file!")
         else:
             logging.info("...Found orbit file")
             check += 1
     for item in root.iter('File_Type'):
         if "AUX_POEORB" not in item.text and "AUX_PREORB" not in item.text and "AUX_RESORB" not in item.text:
-            logging.error("Unknown file type!")
-            sys.exit(1)
+            raise ValueError("Unknown file type!")
         else:
             logging.info("...Found file type {}".format(item.text))
             check += 1
 
     if not check:
-        logging.info("Not a valid state vector file: {}".format(fi))
-        sys.exit(1)
+        raise ValueError("Not a valid state vector file: {}".format(fi))
+
     else:
         logging.info("State vector file verified")
 


### PR DESCRIPTION
`SystemExit` exceptions (typically thrown by calling `sys.exit`) should not be thrown by libraries so that calling apps can handle exceptions in the expected way (via a subclass of `Exception`). 

This: 
* eliminates all `sys.exit` from within library functions, and most entrypoint's `main` functions where possible (e.g., using `parser.error`)
* Add a `DemError` and `GeometryError` exception to `hyp3lib`
* Catches `requests.RequestException` instead of every exception ever when wrapping `requests`
* Reworks `get_asf.py` exceptions the most:
  * The `main` function calls `sys.exit` instead of `exit` ([plain `exit` is intended for use inside the python interpreter, not in library codes](https://docs.python.org/3/library/constants.html#constants-added-by-the-site-module)) 
  * There is no need to capture `SystemExit` and raise an empty exception any more -- python 3 includes the stack trace of `SystemExit` as context to the empty exception, so it doesn't work as intended any ways
  * There's no point in capturing `KeyboardInterrupt` just to send it to `stdout` when it goes to, and is expected to go to, `stderr` any ways... 
  * After the above 2 bullets are taken care of, we're left with just catching an exception and writing the context to the log, but exceptions contain context in python 3, so this is unnecessary
  * Eliminates the entire `try` block b/c of the above 3 bullets. 
--- 

Also:
* Optimizes imports for all scripts touched as an incremental step towards *not* suppressing `flake8` import errors
* drops unnecessary python 2 futures for all scripts touched
* converts most strings I touched to f-strings