### PR TITLE
rtc2color refactor

### DIFF
--- a/hyp3lib/rtc2color.py
+++ b/hyp3lib/rtc2color.py
@@ -109,11 +109,11 @@ def rtc2color(copol_tif: Union[str, Path], crosspol_tif: Union[str, Path], thres
     below_threshold_mask = xp < power_threshold
 
     driver = gdal.GetDriverByName('GTiff')
-    outRaster = driver.Create(out_tif, cols, rows, 3, out_type, ['COMPRESS=LZW'])
-    outRaster.SetGeoTransform((geotransform[0], geotransform[1], 0, geotransform[3], 0, geotransform[5]))
-    outRasterSRS = osr.SpatialReference()
-    outRasterSRS.ImportFromWkt(proj_wkt)
-    outRaster.SetProjection(outRasterSRS.ExportToWkt())
+    out_raster = driver.Create(out_tif, cols, rows, 3, out_type, ['COMPRESS=LZW'])
+    out_raster.SetGeoTransform((geotransform[0], geotransform[1], 0, geotransform[3], 0, geotransform[5]))
+    out_raster_srs = osr.SpatialReference()
+    out_raster_srs.ImportFromWkt(proj_wkt)
+    out_raster.SetProjection(out_raster_srs.ExportToWkt())
 
     logging.info('Calculating color decomposition components')
 
@@ -133,27 +133,27 @@ def rtc2color(copol_tif: Union[str, Path], crosspol_tif: Union[str, Path], thres
         bp[below_threshold_mask] = 0
 
     logging.info('Calculate red channel and save in GeoTIFF')
-    outBand = outRaster.GetRasterBand(1)
+    out_band = out_raster.GetRasterBand(1)
     red = 1.0 + (rp + zp) * scale_factor
     red[invalid_xp_mask] = 0
-    outBand.WriteArray(red)
+    out_band.WriteArray(red)
     del red
 
     logging.info('Calculate green channel and save in GeoTIFF')
-    outBand = outRaster.GetRasterBand(2)
+    out_band = out_raster.GetRasterBand(2)
 
     green = 1.0 + (gp + 2.0 * zp) * scale_factor
     green[invalid_xp_mask] = 0
-    outBand.WriteArray(green)
+    out_band.WriteArray(green)
     del green
 
     logging.info('Calculate blue channel and save in GeoTIFF')
-    outBand = outRaster.GetRasterBand(3)
+    out_band = out_raster.GetRasterBand(3)
     blue = 1.0 + (bp + 5.0 * zp) * scale_factor
     blue[invalid_xp_mask] = 0
-    outBand.WriteArray(blue)
+    out_band.WriteArray(blue)
 
-    outRaster = None  # because gdal is weird
+    out_raster = None  # because gdal is weird
 
 
 def main():

--- a/hyp3lib/rtc2color.py
+++ b/hyp3lib/rtc2color.py
@@ -58,9 +58,11 @@ def rtc2color(fullpolFile, crosspolFile, threshold, geotiff, cleanup=False,
   cp = (data[:rows, :cols]).astype(np.float16)
   data = None
   cp[np.isnan(cp)] = 0
+  # FIXME: do we get negative powers from RTC?
   cp[cp < 0] = 0
   if cleanup == True:
     cp[cp < 0.0039811] = 0
+  # FIXME: Should this be applied *before* the above cleanup?
   if amp == True:
     cp = cp*cp
 
@@ -72,7 +74,9 @@ def rtc2color(fullpolFile, crosspolFile, threshold, geotiff, cleanup=False,
   xp[np.isnan(xp)] = 0
   xp[xp < 0] = 0
   if cleanup == True:
-    xp[xp < 0.0039811] = 0
+      # FIXME: Is this the correct value? 0.0039811 ~= pow(10.0, -24.0 / 10.0),
+      #        or our default threshold
+      xp[xp < 0.0039811] = 0
   if amp == True:
     xp = xp*xp
 
@@ -117,8 +121,12 @@ def rtc2color(fullpolFile, crosspolFile, threshold, geotiff, cleanup=False,
   if real == True:
     red = (2.0*rp*(1 - blue_mask) + zp*blue_mask)
   else:
+    # FIXME: Should we *scale* this? There are values over 1
     red = (2.0*rp*(1 - blue_mask) + zp*blue_mask)*255
+  # FIXME: We should be *adding* 1 I think... values less than 1 will be between
+  #        the no data value and our minimum valid value...
   red[red==0] = 1
+  # FIXME: Is this the right mask (xp > 0)? Red should be mostly copol
   red = red * mask
 
   outBand.WriteArray(red)
@@ -130,6 +138,7 @@ def rtc2color(fullpolFile, crosspolFile, threshold, geotiff, cleanup=False,
   else:
     green = (3.0*np.sqrt(xp)*(1 - blue_mask) + 2.0*zp*blue_mask)*255
   green[green==0]=1
+  # FIXME: Is this the right mask (xp > 0)? Green should be both copol and crosspol
   green = green * mask
   outBand.WriteArray(green)
   green = None
@@ -140,6 +149,7 @@ def rtc2color(fullpolFile, crosspolFile, threshold, geotiff, cleanup=False,
   else:
     blue = (2.0*bp*(1 - blue_mask) + 5.0*zp*blue_mask)*255
   blue[blue==0] = 1
+  # FIXME: Is this the right mask (xp > 0)? Blue should be only copol and no crosspol
   blue = blue * mask
   outBand.WriteArray(blue)
   blue = None

--- a/hyp3lib/rtc2color.py
+++ b/hyp3lib/rtc2color.py
@@ -92,7 +92,7 @@ def rtc2color(copol_tif: Union[str, Path], crosspol_tif: Union[str, Path], thres
     # Find all our no data and bad data pixels
     # NOTE: we're using crosspol here because it will typically have the most bad
     # data and we want the same mask applied to all 3 channels (otherwise, we'll
-    # accidentally be changing colors from intended.
+    # accidentally be changing colors from intended)
     invalid_xp_mask = ~(xp > 0)
     # mask for applying colors
     below_threshold_mask = xp < power_threshold

--- a/hyp3lib/rtc2color.py
+++ b/hyp3lib/rtc2color.py
@@ -36,7 +36,6 @@ def rtc2color(copol_tif: Union[str, Path], crosspol_tif: Union[str, Path], thres
         amp: input TIFs are in amplitude and not power
         real: Output real (floating point) values instead of RGB scaled (0--255) ints
     """
-    # FIXME: Can we just determine if we should use teal?
 
     # Suppress GDAL warnings but raise python exceptions
     # https://gis.stackexchange.com/a/91393
@@ -48,7 +47,6 @@ def rtc2color(copol_tif: Union[str, Path], crosspol_tif: Union[str, Path], thres
 
     # used scale the results to fit inside RGB 1-255 (ints), with 0 for no/bad data
     scale_factor = 1.0 if real else 254.0
-    # FIXME: Float32 or 64?
     out_type = gdal.GDT_Float32 if real else gdal.GDT_Byte
 
     copol = gdal.Open(copol_tif)
@@ -59,15 +57,6 @@ def rtc2color(copol_tif: Union[str, Path], crosspol_tif: Union[str, Path], thres
 
     cols = min(copol.RasterXSize, crosspol.RasterXSize)
     rows = min(copol.RasterYSize, crosspol.RasterYSize)
-
-    # FIXME: do we really need this?
-    # Estimate memory required...
-    size = float(rows * cols) / float(1024 * 1024 * 1024)  # in Gibibyte
-    # print('float16 variables: cp,xp,diff,zp,rp,bp,red = {} GB'.format(size*14))
-    # print('uint8 variables: mask, below_threshold_mask = {} GB".format(size*2))
-    logging.warning(f'Data size is {rows} lines by {cols} samples ({size} GiPixels)')
-    # FIXME: this is the ram usage for *one* variable, not for this whole script
-    logging.warning(f'Estimated Total RAM usage = {size * 16} GiB')
 
     logging.info(f'Reading co-pol image {copol_tif}')
     cp = np.nan_to_num(copol.GetRasterBand(1).ReadAsArray()[:rows, :cols])

--- a/hyp3lib/rtc2color.py
+++ b/hyp3lib/rtc2color.py
@@ -168,11 +168,12 @@ def main():
     parser.add_argument('crosspol', help='the cross-pol GeoTIF')
     parser.add_argument('threshold', type=float, help='decomposition threshold value in dB')
     parser.add_argument('geotiff', help='the output color GeoTIFF file name')
-    parser.add_argument('-c', '--cleanup', action='store_true', help='cleanup artifacts using a -48 db power threshold')
-    parser.add_argument('-t', '--teal', action='store_true',
+    parser.add_argument('-c', '-cleanup', '--cleanup', action='store_true',
+                        help='cleanup artifacts using a -48 db power threshold')
+    parser.add_argument('-t', '-teal', '--teal', action='store_true',
                         help='combine green and blue channels because the volume to simple scattering ratio is high')
-    parser.add_argument('-a', '--amp', action='store_true', help='input is amplitude, not powerscale')
-    parser.add_argument('-r', '--real', action='store_true',
+    parser.add_argument('-a', '-amp', '--amp', action='store_true', help='input is amplitude, not powerscale')
+    parser.add_argument('-r', '-real', '--real', action='store_true',
                         help='output real (floating point) values instead of RGB scaled (0--255) ints')
     args = parser.parse_args()
 
@@ -183,7 +184,7 @@ def main():
     logging.basicConfig(format='%(message)s', level=logging.INFO, handlers=(out, err))
 
     rtc2color(args.copol, args.crosspol, args.threshold, args.geotiff,
-              args.cleanup, args.teal, args.amp, args.float)
+              args.cleanup, args.teal, args.amp, args.real)
 
 
 if __name__ == '__main__':

--- a/hyp3lib/rtc2color.py
+++ b/hyp3lib/rtc2color.py
@@ -68,7 +68,7 @@ def rtc2color(copol_tif: Union[str, Path], crosspol_tif: Union[str, Path], thres
   print('Estimated Total RAM usage = {} GB'.format(size*16))
 
   # Read full-pol image
-  print('Reading full-pol image (%s)' % out_tif)
+  print('Reading co-pol image (%s)' % copol_tif)
   data = fullpol.GetRasterBand(1).ReadAsArray()
   cp = (data[:rows, :cols]).astype(np.float16)
   data = None

--- a/hyp3lib/rtc2color.py
+++ b/hyp3lib/rtc2color.py
@@ -186,7 +186,7 @@ def rtc2color(copol_tif: Union[str, Path], crosspol_tif: Union[str, Path], thres
     out_band.WriteArray(green)
     del green
 
-    logging.info(f'Calculate blue channel and save in GeoTIFF')
+    logging.info('Calculate blue channel and save in GeoTIFF')
     blue = calculate_color_channel(
         copol_data, crosspol_data, threshold=threshold, scale_factor=scale_factor, color='teal' if teal else 'blue'
     )

--- a/hyp3lib/rtc2color.py
+++ b/hyp3lib/rtc2color.py
@@ -1,9 +1,19 @@
-"""Converts a dual-pol RTC to a color GeoTIFF"""
+"""RGB decomposition of a dual-pol RTC
 
-from __future__ import print_function, absolute_import, division, unicode_literals
+The RGB decomposition enhances RTC dual-pol data for visual interpretation. It
+decomposes the co-pol and cross-pol signal into these color channels:
+    red: simple bounce (polarized) with some volume scattering
+    green: volume (depolarized) scattering
+    blue: simple bounce with very low volume scattering
+
+In the case where the volume to simple scattering ratio is larger than expected
+for typical vegetation, such as in glaciated areas or some forest types, a teal
+color (green + blue) is used.
+"""
 
 import argparse
 import os
+
 import numpy as np
 from osgeo import gdal, osr
 
@@ -148,7 +158,7 @@ def main():
         prog=os.path.basename(__file__),
         description=__doc__,
     )
-    parser.add_argument('fullpol', help='name of the full-pol RTC file (input)')
+    parser.add_argument('copol', help='name of the co-pol RTC file (input)')
     parser.add_argument('crosspol', help='name of the cross-pol RTC (input)')
     parser.add_argument('threshold', help='threshold value in dB (input)')
     parser.add_argument('geotiff', help='name of color GeoTIFF file (output)')
@@ -158,7 +168,7 @@ def main():
     parser.add_argument('-float', action='store_true', help='save as floating point')
     args = parser.parse_args()
 
-    rtc2color(args.fullpol, args.crosspol, args.threshold, args.geotiff,
+    rtc2color(args.copol, args.crosspol, args.threshold, args.geotiff,
               args.cleanup, args.teal, args.amp, args.float)
 
 

--- a/hyp3lib/rtc2color.py
+++ b/hyp3lib/rtc2color.py
@@ -162,6 +162,7 @@ def main():
     parser = argparse.ArgumentParser(
         prog=os.path.basename(__file__),
         description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument('copol', help='the co-pol RTC GeoTIF')
     parser.add_argument('crosspol', help='the cross-pol GeoTIF')


### PR DESCRIPTION
We received an user question about our RGB decompositions:

*Granule: `S1B_IW_GRDH_1SDV_20200515T233216_20200515T233241_021599_02900D_FD9E`*

> in the recent RGB decompositions I have ordered from hyp3 that the areas of water, that used to be in shades of blue, are now uniformly black.
![image](https://user-images.githubusercontent.com/7882693/84715826-18e8a180-af1e-11ea-9b36-4df25286ae45.png)

> The Browse image from VERTEX for the exact same granule… which is what I was expecting the image I downloaded to look like
![image](https://user-images.githubusercontent.com/7882693/84715779-f9ea0f80-af1d-11ea-8196-1f15bde6ce6a.png)

> Now I recall that there is a selection of thresholds of dB that was implemented to account for when we had swaths that were contaminated with high winds (to reduce the amount of missed water pixels)….  My understanding of that if I change the threshold from -24 dB wouldn’t solve this issue..

> The black values that I get from the HYP3 image, do seem to line up with blue water pixels ok, but I am trying to decide if the the pixels with red and green pixels look the same in both images…  hard to tell in the browse images.. and I comparing them side by side as images is maybe not the best way to qualitatively check this… but I would have said that they are not the same.

----
There is very little documentation of the RGB Decomposition, but the wesbite indicates this:

```
The RGB decomposition enhances RTC dual-pol data for visual interpretation. It
decomposes the co-pol and cross-pol signal into these color channels:
    red: simple bounce (polarized) with some volume scattering
    green: volume (depolarized) scattering
    blue: simple bounce with very low volume scattering

In the case where the volume to simple scattering ratio is larger than expected
for typical vegetation, such as in glaciated areas or some forest types, a teal
color (green + blue) can be used.
```
When you step through this function, this line

https://github.com/asfadmin/hyp3-lib/commit/5db7b99deb94c6d6c4392f05b55b5214b088984b#diff-452b8f27dccc3ac8ef4c12da7f7f10acR127

ends up removing the blues entirely. `blue` just before that line looks like:
![image](https://user-images.githubusercontent.com/7882693/84716228-01f67f00-af1f-11ea-9a0e-0c4786ba2f33.png)

and just after, `blue` looks like:
![image](https://user-images.githubusercontent.com/7882693/84716266-176ba900-af1f-11ea-9a79-3ee7745bfbcd.png)

That mask is defined here: 

https://github.com/asfadmin/hyp3-lib/blob/develop/hyp3lib/rtc2color.py#L87

**Importantly** after `xp` is cleaned: 

https://github.com/asfadmin/hyp3-lib/blob/develop/hyp3lib/rtc2color.py#L59-L67

So, applying that mask, we're saying: *mask out blues everywhere the crosspol power(amplitude?) is below the cleanup threshold*

**But**, because blue is defined as "simple bounce with very low volume scattering" I believe we'd want to actually, either:
* **mask out blues everywhere the crosspol power(amplitude?) is ~~below~~ above the cleanup threshold** (that is, blue is only in places that have basically no cross polarization)
* **mask out blues everywhere the *copol* power(amplitude?) is below the cleanup threshold**
* **Neither of the above because of other issues**
----
## Other issues:

There are a number of other issues I've found around/in `rtc2color.py` and I'll open comment threads to discuss them -- these should be resolved first, before we discuss the above issue/resolution
 