### PR TITLE
Fix cleaning threshold for power data

### DIFF
--- a/src/rtc2color.py
+++ b/src/rtc2color.py
@@ -14,6 +14,9 @@ def rtc2color(fullpolFile, crosspolFile, threshold, geotiff, cleanup=False,
   gdal.UseExceptions()
   gdal.PushErrorHandler('CPLQuietErrorHandler')
 
+  # Threshold for cleaning *power* data
+  clean_threshold = pow(10.0, -48.0 / 10)
+
   # Convert threshold to power scale
   g = pow(10.0, np.float32(threshold)/10.0)
 
@@ -48,10 +51,10 @@ def rtc2color(fullpolFile, crosspolFile, threshold, geotiff, cleanup=False,
   data = None
   cp[np.isnan(cp)] = 0
   cp[cp < 0] = 0
-  if cleanup == True:
-    cp[cp < 0.0039811] = 0
   if amp == True:
-    cp = cp*cp
+      cp = cp * cp
+  if cleanup == True:
+    cp[cp < clean_threshold] = 0
 
   # Read cross-pol image
   print('Reading cross-pol image (%s)' % crosspolFile)
@@ -60,10 +63,10 @@ def rtc2color(fullpolFile, crosspolFile, threshold, geotiff, cleanup=False,
   data = None
   xp[np.isnan(xp)] = 0
   xp[xp < 0] = 0
-  if cleanup == True:
-    xp[xp < 0.0039811] = 0
   if amp == True:
-    xp = xp*xp
+      xp = xp * xp
+  if cleanup == True:
+    xp[xp < clean_threshold] = 0
 
   # Calculate color decomposition
   print('Calculating color decomposition components')


### PR DESCRIPTION
Because the cleaning threshold was applied before the conversion from
amplitude to power, the cleaning threshold is applied differently to
these two types.

The hard coded value here was the correct value for amplitude data.

*Note: `0.0039811 = pow(10.0, -24.0 / 10.0)` and intended for amplitude,
so the corresponding threshold in power is `pow(10.0, -48.0 / 10.0)`.*

This converts to power before cleaning, and then applies the
corresponding power cleaning threshold afterwards.

---

**Testing:**

This fix has been cherry-picked into test in f90b3b4e7a052411594e1cbc097f172f7a9e8eab so you can run any test you see fit there. See discussion in #170 for more context. 


<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/asfadmin/hyp3-lib/compare/master...develop?template=release.md
 
NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->