### PR TITLE
Fix unbound local in get_dem

### DIFF
--- a/hyp3lib/get_dem.py
+++ b/hyp3lib/get_dem.py
@@ -352,14 +352,16 @@ def get_dem(x_min,y_min,x_max,y_max,outfile,post=None,processes=1,demName=None,l
     p.join()
 
     #os.system("gdalbuildvrt temp.vrt DEM/*.tif")
-    if "SRTMGL1" in demname:
+    if "SRTMGL" in demname:
         nodata = -32768
     elif "GIMP" in demname:
         nodata = None
     elif "REMA" in demname:
         nodata = 0
     elif "NED" in demname or "EU_DEM_V11" in demname:
-        nodata = -3.4028234663852886e+38 
+        nodata = -3.4028234663852886e+38
+    else:
+        raise DemError(f'Unkown NoData value for DEM {demname}')
 
     writeVRT(demproj, nodata, tile_list, poly_list, 'temp.vrt')
  

--- a/hyp3lib/get_dem.py
+++ b/hyp3lib/get_dem.py
@@ -361,7 +361,7 @@ def get_dem(x_min,y_min,x_max,y_max,outfile,post=None,processes=1,demName=None,l
     elif "NED" in demname or "EU_DEM_V11" in demname:
         nodata = -3.4028234663852886e+38
     else:
-        raise DemError(f'Unkown NoData value for DEM {demname}')
+        raise DemError(f'Unable to determine NoData value for DEM {demname}')
 
     writeVRT(demproj, nodata, tile_list, poly_list, 'temp.vrt')
  


### PR DESCRIPTION
Some processes are failing with an unbound local error because `nodata` is not set if unknown.

Also, loosen `SRTM` matching because both `SRTMGL3` and `SRTMGL1` are available 