### PR TITLE
Publish releases on PyPI.org

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -135,6 +135,13 @@ jobs:
           echo "Uploading version ${SDIST_VERSION} to S3-PyPI"
           s3pypi --bucket hyp3-pypi --force --verbose
 
+      - name: Upload to PyPI.org
+        if: github.ref == 'refs/heads/master'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TOOLS_PYPI_PAK }}
+
 
   verify-packaging:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will publish the pip installable package to PyPI.org for any merge to master