### PR TITLE
Update to pyproj 2 style syntax

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -20,7 +20,7 @@ dependencies:
   - netCDF4
   - numpy
   - pillow
-  - proj
+  - proj>=2
   - pyshp
   - requests
   - scipy

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'numpy',
         'gdal',
         'pillow',
-        'pyproj',
+        'pyproj~=2.0',
         'pyshp',
         'requests',
         'scipy',


### PR DESCRIPTION
Fixes error in InSAR ISCE processing

Note:
* `transform_bounds` is only used internally to `get_dem`: https://github.com/search?q=org%3Aasfadmin+transform_bounds&type=Code
* `tranform_point` is only used internally to `get_dem`: https://github.com/search?q=org%3Aasfadmin+transform_point&type=Code
* pyproj can transform lists of x-y pairs, so there is no need to do this point-wise